### PR TITLE
Make it possible to compile the stack with CONFIG_POSIX_API=y

### DIFF
--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -69,7 +69,6 @@ config BACDL_BIP
     bool "BACnet BIP datalink"
     select NETWORKING
     select NET_SOCKETS
-    select NET_SOCKETS_POSIX_NAMES
     select NET_UDP
     select NET_IPV4
     help
@@ -79,7 +78,6 @@ config BACDL_BIP6
     bool "BACnet BIP6 datalink"
     select NETWORKING
     select NET_SOCKETS
-    select NET_SOCKETS_POSIX_NAMES
     select NET_UDP
     select NET_IPV6
     help

--- a/zephyr/subsys/bacnet_datalink/bip-init.c
+++ b/zephyr/subsys/bacnet_datalink/bip-init.c
@@ -50,21 +50,6 @@ static char ipv4_addr_str[16] = { 0 };
 static char ipv4_addr_str[] = "";
 #endif
 
-/**
- * @brief Return a string representation of an IPv4 address
- * @param a - IPv4 address
- * @return Pointer to global string
- */
-char *inet_ntoa(struct in_addr *a)
-{
-    if (IS_ENABLED(CONFIG_BACNETSTACK_LOG_LEVEL)) {
-        snprintf(
-            ipv4_addr_str, sizeof(ipv4_addr_str), "%d.%d.%d.%d", a->s4_addr[0],
-            a->s4_addr[1], a->s4_addr[2], a->s4_addr[3]);
-    }
-
-    return &ipv4_addr_str[0];
-}
 
 /**
  * @brief Print the IPv4 address with debug info
@@ -78,7 +63,8 @@ static void debug_print_ipv4(
     const unsigned int count)
 {
     LOG_DBG(
-        "%s %s:%hu (%u bytes)", str, inet_ntoa((struct in_addr *)&addr),
+        "%s %s:%hu (%u bytes)", str,
+        net_addr_ntop(AF_INET, addr, ipv4_addr_str, sizeof(ipv4_addr_str)),
         ntohs(port), count);
 }
 

--- a/zephyr/subsys/bacnet_datalink/bip6-init.c
+++ b/zephyr/subsys/bacnet_datalink/bip6-init.c
@@ -51,31 +51,11 @@ static char ipv6_addr_str[] = "";
 static char *inet6_ntoa(struct in6_addr *a)
 {
 #if CONFIG_BACNETSTACK_LOG_LEVEL
-    uint8_t x = 0;
-    uint8_t d = 0;
-    uint8_t non_zero_count = 0;
-
     /* Avoid overwhelming the logging system */
     while (log_buffered_cnt()) {
         k_sleep(K_MSEC(1));
     }
-
-    for (x = 0; x < IP6_ADDRESS_MAX; x += 2) {
-        if (a->s6_addr[x] | a->s6_addr[x + 1]) {
-            non_zero_count++;
-            d += snprintf(
-                &ipv6_addr_str[d], sizeof(ipv6_addr_str), "%02X%02X",
-                a->s6_addr[x], a->s6_addr[x + 1]);
-        }
-
-        if (x < 14) {
-            d += snprintf(&ipv6_addr_str[d], sizeof(ipv6_addr_str), ":");
-        }
-    }
-
-    if (!non_zero_count) {
-        snprintf(&ipv6_addr_str[0], sizeof(ipv6_addr_str), "undefined");
-    }
+    net_addr_ntop(AF_INET6, a, &ipv6_addr_str[0], sizeof(ipv6_addr_str));
 #endif
     return &ipv6_addr_str[0];
 }

--- a/zephyr/subsys/bacnet_datalink/bip6-init.c
+++ b/zephyr/subsys/bacnet_datalink/bip6-init.c
@@ -223,7 +223,7 @@ void bip6_get_my_address(BACNET_ADDRESS *addr)
  *
  * @param addr - network IPv6 address
  */
-bool bip6_set_addr(BACNET_IP6_ADDRESS *addr)
+bool bip6_set_addr(const BACNET_IP6_ADDRESS *addr)
 {
     return bvlc6_address_copy(&BIP6_Addr, addr);
 }
@@ -243,7 +243,7 @@ bool bip6_get_addr(BACNET_IP6_ADDRESS *addr)
  *
  * @param addr - network IPv6 address
  */
-bool bip6_set_broadcast_addr(BACNET_IP6_ADDRESS *addr)
+bool bip6_set_broadcast_addr(const BACNET_IP6_ADDRESS *addr)
 {
     return bvlc6_address_copy(&BIP6_Broadcast_Addr, addr);
 }
@@ -269,7 +269,7 @@ bool bip6_get_broadcast_addr(BACNET_IP6_ADDRESS *addr)
  * @return Upon successful completion, returns the number of bytes sent.
  *  Otherwise, -1 shall be returned and errno set to indicate the error.
  */
-int bip6_send_mpdu(BACNET_IP6_ADDRESS *dest, uint8_t *mtu, uint16_t mtu_len)
+int bip6_send_mpdu(const BACNET_IP6_ADDRESS *dest, const uint8_t *mtu, uint16_t mtu_len)
 {
     struct sockaddr_in6 bvlc_dest = { 0 };
     uint16_t addr16[8];
@@ -522,7 +522,7 @@ bool bip6_init(char *ifname)
         sizeof(struct in6_addr));
     /* Let system not choose the interface */
     join_request.ipv6mr_ifindex = BIP6_Socket_Scope_Id;
-    status = setsockopt(
+    status = zsock_setsockopt(
         BIP6_Socket, IPPROTO_IPV6, IPV6_ADD_MEMBERSHIP, &join_request,
         sizeof(join_request));
     if (status < 0) {


### PR DESCRIPTION
This code already uses the zephyr `zsock_*` functions so the deprecated NET_SOCKETS_POSIX_NAMES can be removed.
It is only `inet_ntoa` that create a conflict with the POSIX API, and it is replaced with the zephyr `net_addr_ntop`

To test the changes with one of the samples with add the following to proj.conf
CONFIG_POSIX_API=y
CONFIG_POSIX_CLOCK=y
