### PR TITLE
Load only BACnet settings

### DIFF
--- a/zephyr/subsys/bacnet_settings/bacnet_storage.c
+++ b/zephyr/subsys/bacnet_settings/bacnet_storage.c
@@ -249,7 +249,7 @@ int bacnet_storage_load(void)
 {
     int rc = 0;
 
-    rc = settings_load();
+    rc = settings_load_subtree(bacnet_storage_handler.name);
     if (rc) {
         LOG_ERR("settings_load failed (err %d)", rc);
         return rc;


### PR DESCRIPTION
For some subsystems like Bluetooth `settings_load` should not be called before the Bluetooth stack has fully initialized. 
This PR use `settings_load_subtree` to only load BACnet settings. 
The other option would be to not load the setting and wait for `settings_load` to becalled from the application.