### PR TITLE
Refactor BACnet test CMakeLists.txt files to streamline source files

### DIFF
--- a/zephyr/tests/bacnet/abort/CMakeLists.txt
+++ b/zephyr/tests/bacnet/abort/CMakeLists.txt
@@ -18,14 +18,12 @@ string(REGEX REPLACE
   ${CMAKE_CURRENT_SOURCE_DIR})
 get_filename_component(BACNET_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
-
 if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
     ${BACNET_BASE}/src/bacnet/abort.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/alarm_ack/CMakeLists.txt
+++ b/zephyr/tests/bacnet/alarm_ack/CMakeLists.txt
@@ -25,21 +25,16 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
     ${BACNET_BASE}/src/bacnet/alarm_ack.c
-    )
-
-  get_filename_component(BACNET_SRC ${BACNET_SRC_PATH} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/datetime.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/timestamp.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/arf/CMakeLists.txt
+++ b/zephyr/tests/bacnet/arf/CMakeLists.txt
@@ -25,21 +25,13 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
     ${BACNET_BASE}/src/bacnet/arf.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
     ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
-    )
-
-  get_filename_component(BACNET_SRC ${BACNET_SRC_PATH} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/basic/sys/days.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/awf/CMakeLists.txt
+++ b/zephyr/tests/bacnet/awf/CMakeLists.txt
@@ -25,21 +25,13 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
     ${BACNET_BASE}/src/bacnet/awf.c
-    )
-
-  get_filename_component(BACNET_SRC ${BACNET_SRC_PATH} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/bacapp/CMakeLists.txt
+++ b/zephyr/tests/bacnet/bacapp/CMakeLists.txt
@@ -25,43 +25,38 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${BACNET_BASE}/src/bacnet/authentication_factor.c
     ${BACNET_BASE}/src/bacnet/bacapp.c
-    ${BACNET_BASE}/src/bacnet/datalink/bvlc.c
+    ${BACNET_BASE}/src/bacnet/access_rule.c
+    ${BACNET_BASE}/src/bacnet/authentication_factor.c
     ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
-    )
-
-  get_filename_component(BACNET_SRC ${BACNET_SRC_PATH} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/access_rule.c
-    ${BACNET_SRC}/bacaction.c
-    ${BACNET_SRC}/bacaddr.c
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacdest.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/baclog.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/channel_value.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/basic/sys/days.c
-    ${BACNET_SRC}/bacdevobjpropref.c
-    ${BACNET_SRC}/bactext.c
-    ${BACNET_SRC}/indtext.c
-    ${BACNET_SRC}/lighting.c
-    ${BACNET_SRC}/shed_level.c
-    ${BACNET_SRC}/timer_value.c
-    ${BACNET_SRC}/hostnport.c
-    ${BACNET_SRC}/dailyschedule.c
-    ${BACNET_SRC}/weeklyschedule.c
-    ${BACNET_SRC}/calendar_entry.c
-    ${BACNET_SRC}/special_event.c
-    ${BACNET_SRC}/basic/sys/bigend.c
-    ${BACNET_SRC}/bactimevalue.c
-    ${BACNET_SRC}/secure_connect.c
+    ${BACNET_BASE}/src/bacnet/bacaction.c
+    ${BACNET_BASE}/src/bacnet/bacaddr.c
+    ${BACNET_BASE}/src/bacnet/bacdest.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacdevobjpropref.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/baclog.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/bactext.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/datetime.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/hostnport.c
+    ${BACNET_BASE}/src/bacnet/lighting.c
+    ${BACNET_BASE}/src/bacnet/shed_level.c
+    ${BACNET_BASE}/src/bacnet/timer_value.c
+    ${BACNET_BASE}/src/bacnet/timestamp.c
+    ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_BASE}/src/bacnet/datalink/bvlc.c
+    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
+    ${BACNET_BASE}/src/bacnet/bactimevalue.c
+    ${BACNET_BASE}/src/bacnet/dailyschedule.c
+    ${BACNET_BASE}/src/bacnet/calendar_entry.c
+    ${BACNET_BASE}/src/bacnet/special_event.c
+    ${BACNET_BASE}/src/bacnet/channel_value.c
+    ${BACNET_BASE}/src/bacnet/secure_connect.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/bacdcode/CMakeLists.txt
+++ b/zephyr/tests/bacnet/bacdcode/CMakeLists.txt
@@ -25,19 +25,14 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
     ${BACNET_BASE}/src/bacnet/bacdcode.c
-    )
-
-  get_filename_component(BACNET_SRC ${BACNET_SRC_PATH} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/basic/sys/days.c
-    ${BACNET_SRC}/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/datetime.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/bacdevobjpropref/CMakeLists.txt
+++ b/zephyr/tests/bacnet/bacdevobjpropref/CMakeLists.txt
@@ -25,42 +25,37 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${BACNET_BASE}/src/bacnet/baclog.c
+    ${BACNET_BASE}/src/bacnet/bacdevobjpropref.c
     ${BACNET_BASE}/src/bacnet/access_rule.c
-    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
-    ${BACNET_BASE}/src/bacnet/shed_level.c
-    ${BACNET_BASE}/src/bacnet/dailyschedule.c
-    ${BACNET_BASE}/src/bacnet/bacdest.c
     ${BACNET_BASE}/src/bacnet/authentication_factor.c
-    ${BACNET_BASE}/src/bacnet/timer_value.c
+    ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
+    ${BACNET_BASE}/src/bacnet/bacaction.c
     ${BACNET_BASE}/src/bacnet/bacaddr.c
     ${BACNET_BASE}/src/bacnet/bacapp.c
-    ${BACNET_BASE}/src/bacnet/lighting.c
-    ${BACNET_BASE}/src/bacnet/bactimevalue.c
-    ${BACNET_BASE}/src/bacnet/hostnport.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacdest.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/baclog.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/bactext.c
     ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/datetime.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_BASE}/src/bacnet/hostnport.c
+    ${BACNET_BASE}/src/bacnet/lighting.c
+    ${BACNET_BASE}/src/bacnet/shed_level.c
+    ${BACNET_BASE}/src/bacnet/timer_value.c
+    ${BACNET_BASE}/src/bacnet/timestamp.c
+    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
+    ${BACNET_BASE}/src/bacnet/bactimevalue.c
+    ${BACNET_BASE}/src/bacnet/dailyschedule.c
+    ${BACNET_BASE}/src/bacnet/calendar_entry.c
     ${BACNET_BASE}/src/bacnet/special_event.c
     ${BACNET_BASE}/src/bacnet/channel_value.c
-    ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
-    ${BACNET_BASE}/src/bacnet/indtext.c
     ${BACNET_BASE}/src/bacnet/secure_connect.c
-    ${BACNET_BASE}/src/bacnet/bactext.c
-    ${BACNET_BASE}/src/bacnet/calendar_entry.c
-    ${BACNET_BASE}/src/bacnet/bacdevobjpropref.c
-    ${BACNET_BASE}/src/bacnet/bacaction.c
-    )
-
-  get_filename_component(BACNET_SRC ${BACNET_SRC_PATH} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/basic/sys/days.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/bacerror/CMakeLists.txt
+++ b/zephyr/tests/bacnet/bacerror/CMakeLists.txt
@@ -25,22 +25,15 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
     ${BACNET_BASE}/src/bacnet/bacerror.c
-    )
-
-  get_filename_component(BACNET_SRC ${BACNET_SRC_PATH} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/basic/sys/days.c
-    ${BACNET_SRC}/bacdevobjpropref.c
+    ${BACNET_BASE}/src/bacnet/abort.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/reject.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/bacint/CMakeLists.txt
+++ b/zephyr/tests/bacnet/bacint/CMakeLists.txt
@@ -18,15 +18,13 @@ string(REGEX REPLACE
   ${CMAKE_CURRENT_SOURCE_DIR})
 get_filename_component(BACNET_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
-
 if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
     ${BACNET_BASE}/src/bacnet/bacint.c
     ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/bacpropstates/CMakeLists.txt
+++ b/zephyr/tests/bacnet/bacpropstates/CMakeLists.txt
@@ -25,22 +25,13 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
     ${BACNET_BASE}/src/bacnet/bacpropstates.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
     ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
-    )
-
-  get_filename_component(BACNET_SRC ${BACNET_SRC_PATH} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/basic/sys/days.c
-    ${BACNET_SRC}/bacdevobjpropref.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/bacreal/CMakeLists.txt
+++ b/zephyr/tests/bacnet/bacreal/CMakeLists.txt
@@ -25,13 +25,12 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${BACNET_BASE}/src/bacnet/bacint.c
-    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
-    ${BACNET_BASE}/src/bacnet/bacstr.c
-    ${BACNET_BASE}/src/bacnet/bacdcode.c
     ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/bacstr/CMakeLists.txt
+++ b/zephyr/tests/bacnet/bacstr/CMakeLists.txt
@@ -18,14 +18,12 @@ string(REGEX REPLACE
   ${CMAKE_CURRENT_SOURCE_DIR})
 get_filename_component(BACNET_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
-
 if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
     ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/basic/binding/address/CMakeLists.txt
+++ b/zephyr/tests/bacnet/basic/binding/address/CMakeLists.txt
@@ -25,45 +25,38 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${BACNET_BASE}/src/bacnet/baclog.c
-    ${BACNET_BASE}/src/bacnet/access_rule.c
-    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
-    ${BACNET_BASE}/src/bacnet/shed_level.c
-    ${BACNET_BASE}/src/bacnet/dailyschedule.c
-    ${BACNET_BASE}/src/bacnet/bacdest.c
-    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
-    ${BACNET_BASE}/src/bacnet/datetime.c
-    ${BACNET_BASE}/src/bacnet/authentication_factor.c
-    ${BACNET_BASE}/src/bacnet/timer_value.c
-    ${BACNET_BASE}/src/bacnet/bacapp.c
-    ${BACNET_BASE}/src/bacnet/lighting.c
-    ${BACNET_BASE}/src/bacnet/bactimevalue.c
-    ${BACNET_BASE}/src/bacnet/hostnport.c
-    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
-    ${BACNET_BASE}/src/bacnet/special_event.c
-    ${BACNET_BASE}/src/bacnet/timestamp.c
-    ${BACNET_BASE}/src/bacnet/channel_value.c
-    ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
-    ${BACNET_BASE}/src/bacnet/secure_connect.c
     ${BACNET_BASE}/src/bacnet/basic/binding/address.c
-    ${BACNET_BASE}/src/bacnet/calendar_entry.c
+    ${BACNET_BASE}/src/bacnet/access_rule.c
+    ${BACNET_BASE}/src/bacnet/authentication_factor.c
+    ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
+    ${BACNET_BASE}/src/bacnet/bacaction.c
+    ${BACNET_BASE}/src/bacnet/bacaddr.c
+    ${BACNET_BASE}/src/bacnet/bacapp.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacdest.c
     ${BACNET_BASE}/src/bacnet/bacdevobjpropref.c
-    )
-
-  get_filename_component(BACNET_BINDING_SRC ${BACNET_SRC_PATH} PATH)
-  get_filename_component(BACNET_BASIC_SRC ${BACNET_BINDING_SRC} PATH)
-  get_filename_component(BACNET_SRC ${BACNET_BASIC_SRC} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/bacaction.c
-    ${BACNET_SRC}/bacaddr.c
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/bactext.c
-    ${BACNET_SRC}/indtext.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/baclog.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/bactext.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/datetime.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_BASE}/src/bacnet/hostnport.c
+    ${BACNET_BASE}/src/bacnet/lighting.c
+    ${BACNET_BASE}/src/bacnet/shed_level.c
+    ${BACNET_BASE}/src/bacnet/timer_value.c
+    ${BACNET_BASE}/src/bacnet/timestamp.c
+    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
+    ${BACNET_BASE}/src/bacnet/bactimevalue.c
+    ${BACNET_BASE}/src/bacnet/dailyschedule.c
+    ${BACNET_BASE}/src/bacnet/calendar_entry.c
+    ${BACNET_BASE}/src/bacnet/special_event.c
+    ${BACNET_BASE}/src/bacnet/channel_value.c
+    ${BACNET_BASE}/src/bacnet/secure_connect.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   add_definitions(-DBACNET_ADDRESS_CACHE_FILE=1)

--- a/zephyr/tests/bacnet/basic/object/acc/CMakeLists.txt
+++ b/zephyr/tests/bacnet/basic/object/acc/CMakeLists.txt
@@ -29,52 +29,44 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH TEST_OBJECT_INCLUDE $ENV{ZEPHYR_BASE} ${TEST_OBJECT_SRC})
   list(APPEND INCLUDE ${BACNET_INCLUDE} ${TEST_OBJECT_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${TEST_OBJECT_SRC}/property_test.c
-    ${BACNET_BASE}/src/bacnet/authentication_factor.c
     ${BACNET_BASE}/src/bacnet/basic/object/acc.c
+    ${BACNET_BASE}/src/bacnet/access_rule.c
+    ${BACNET_BASE}/src/bacnet/authentication_factor.c
     ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
+    ${BACNET_BASE}/src/bacnet/bacaction.c
+    ${BACNET_BASE}/src/bacnet/bacaddr.c
+    ${BACNET_BASE}/src/bacnet/bacapp.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacdest.c
+    ${BACNET_BASE}/src/bacnet/bacdevobjpropref.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/baclog.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/bactext.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/debug.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/keylist.c
+    ${BACNET_BASE}/src/bacnet/datetime.c
+    ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_BASE}/src/bacnet/hostnport.c
+    ${BACNET_BASE}/src/bacnet/lighting.c
+    ${BACNET_BASE}/src/bacnet/proplist.c
+    ${BACNET_BASE}/src/bacnet/shed_level.c
+    ${BACNET_BASE}/src/bacnet/timer_value.c
+    ${BACNET_BASE}/src/bacnet/timestamp.c
+    ${BACNET_BASE}/src/bacnet/wp.c
+    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
+    ${BACNET_BASE}/src/bacnet/bactimevalue.c
+    ${BACNET_BASE}/src/bacnet/dailyschedule.c
+    ${BACNET_BASE}/src/bacnet/calendar_entry.c
+    ${BACNET_BASE}/src/bacnet/special_event.c
+    ${BACNET_BASE}/src/bacnet/channel_value.c
+    ${BACNET_BASE}/src/bacnet/secure_connect.c
+    ${BACNET_TEST_PATH}/src/main.c
+    ${BACNET_BASE}/test/bacnet/basic/object/test/property_test.c
     )
-
-  get_filename_component(BACNET_OBJECT_SRC ${BACNET_SRC_PATH} PATH)
-  get_filename_component(BACNET_BASIC_SRC ${BACNET_OBJECT_SRC} PATH)
-  get_filename_component(BACNET_SRC ${BACNET_BASIC_SRC} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/access_rule.c
-    ${BACNET_SRC}/bacaction.c
-    ${BACNET_SRC}/bacaddr.c
-    ${BACNET_SRC}/bacapp.c
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacdest.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/baclog.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/channel_value.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/bacdevobjpropref.c
-    ${BACNET_SRC}/bactext.c
-    ${BACNET_SRC}/cov.c
-    ${BACNET_SRC}/indtext.c
-    ${BACNET_SRC}/lighting.c
-    ${BACNET_SRC}/proplist.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/wp.c
-    ${BACNET_SRC}/shed_level.c
-    ${BACNET_SRC}/timer_value.c
-    ${BACNET_SRC}/hostnport.c
-    ${BACNET_SRC}/dailyschedule.c
-    ${BACNET_SRC}/weeklyschedule.c
-    ${BACNET_SRC}/calendar_entry.c
-    ${BACNET_SRC}/special_event.c
-    ${BACNET_SRC}/bactimevalue.c
-    ${BACNET_SRC}/basic/sys/bigend.c
-    ${BACNET_SRC}/basic/sys/days.c
-    ${BACNET_SRC}/basic/sys/debug.c
-    ${BACNET_SRC}/basic/sys/keylist.c
-    ${BACNET_SRC}/secure_connect.c
-  )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")
   find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/zephyr/tests/bacnet/basic/object/access_credential/CMakeLists.txt
+++ b/zephyr/tests/bacnet/basic/object/access_credential/CMakeLists.txt
@@ -25,49 +25,42 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
     ${BACNET_BASE}/src/bacnet/basic/object/access_credential.c
+    ${BACNET_BASE}/src/bacnet/access_rule.c
+    ${BACNET_BASE}/src/bacnet/assigned_access_rights.c
+    ${BACNET_BASE}/src/bacnet/authentication_factor.c
     ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
-    )
-
-  get_filename_component(BACNET_OBJECT_SRC ${BACNET_SRC_PATH} PATH)
-  get_filename_component(BACNET_BASIC_SRC ${BACNET_OBJECT_SRC} PATH)
-  get_filename_component(BACNET_SRC ${BACNET_BASIC_SRC} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/access_rule.c
-    ${BACNET_SRC}/bacaction.c
-    ${BACNET_SRC}/bacaddr.c
-    ${BACNET_SRC}/bacapp.c
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacdest.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/baclog.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/channel_value.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/basic/sys/days.c
-    ${BACNET_SRC}/bacdevobjpropref.c
-    ${BACNET_SRC}/bactext.c
-    ${BACNET_SRC}/indtext.c
-    ${BACNET_SRC}/lighting.c
-    ${BACNET_SRC}/proplist.c
-    ${BACNET_SRC}/credential_authentication_factor.c
-    ${BACNET_SRC}/authentication_factor.c
-    ${BACNET_SRC}/assigned_access_rights.c
-    ${BACNET_SRC}/wp.c
-    ${BACNET_SRC}/shed_level.c
-    ${BACNET_SRC}/timer_value.c
-    ${BACNET_SRC}/hostnport.c
-    ${BACNET_SRC}/dailyschedule.c
-    ${BACNET_SRC}/weeklyschedule.c
-    ${BACNET_SRC}/calendar_entry.c
-    ${BACNET_SRC}/special_event.c
-    ${BACNET_SRC}/basic/sys/bigend.c
-    ${BACNET_SRC}/bactimevalue.c
-    ${BACNET_SRC}/secure_connect.c
+    ${BACNET_BASE}/src/bacnet/bacaction.c
+    ${BACNET_BASE}/src/bacnet/bacaddr.c
+    ${BACNET_BASE}/src/bacnet/bacapp.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacdest.c
+    ${BACNET_BASE}/src/bacnet/bacdevobjpropref.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/baclog.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/bactext.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/credential_authentication_factor.c
+    ${BACNET_BASE}/src/bacnet/datetime.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_BASE}/src/bacnet/hostnport.c
+    ${BACNET_BASE}/src/bacnet/lighting.c
+    ${BACNET_BASE}/src/bacnet/proplist.c
+    ${BACNET_BASE}/src/bacnet/shed_level.c
+    ${BACNET_BASE}/src/bacnet/timer_value.c
+    ${BACNET_BASE}/src/bacnet/timestamp.c
+    ${BACNET_BASE}/src/bacnet/wp.c
+    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
+    ${BACNET_BASE}/src/bacnet/bactimevalue.c
+    ${BACNET_BASE}/src/bacnet/dailyschedule.c
+    ${BACNET_BASE}/src/bacnet/calendar_entry.c
+    ${BACNET_BASE}/src/bacnet/special_event.c
+    ${BACNET_BASE}/src/bacnet/channel_value.c
+    ${BACNET_BASE}/src/bacnet/secure_connect.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/basic/object/access_door/CMakeLists.txt
+++ b/zephyr/tests/bacnet/basic/object/access_door/CMakeLists.txt
@@ -25,47 +25,40 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
+    ${BACNET_BASE}/src/bacnet/basic/object/access_door.c
+    ${BACNET_BASE}/src/bacnet/access_rule.c
     ${BACNET_BASE}/src/bacnet/authentication_factor.c
     ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
-    ${BACNET_BASE}/src/bacnet/basic/object/access_door.c
-    )
-
-  get_filename_component(BACNET_OBJECT_SRC ${BACNET_SRC_PATH} PATH)
-  get_filename_component(BACNET_BASIC_SRC ${BACNET_OBJECT_SRC} PATH)
-  get_filename_component(BACNET_SRC ${BACNET_BASIC_SRC} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/access_rule.c
-    ${BACNET_SRC}/bacaction.c
-    ${BACNET_SRC}/bacaddr.c
-    ${BACNET_SRC}/bacapp.c
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacdest.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/baclog.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/channel_value.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/basic/sys/days.c
-    ${BACNET_SRC}/bacdevobjpropref.c
-    ${BACNET_SRC}/bactext.c
-    ${BACNET_SRC}/indtext.c
-    ${BACNET_SRC}/lighting.c
-    ${BACNET_SRC}/proplist.c
-    ${BACNET_SRC}/wp.c
-    ${BACNET_SRC}/shed_level.c
-    ${BACNET_SRC}/timer_value.c
-    ${BACNET_SRC}/hostnport.c
-    ${BACNET_SRC}/dailyschedule.c
-    ${BACNET_SRC}/weeklyschedule.c
-    ${BACNET_SRC}/calendar_entry.c
-    ${BACNET_SRC}/special_event.c
-    ${BACNET_SRC}/basic/sys/bigend.c
-    ${BACNET_SRC}/bactimevalue.c
-    ${BACNET_SRC}/secure_connect.c
+    ${BACNET_BASE}/src/bacnet/bacaction.c
+    ${BACNET_BASE}/src/bacnet/bacaddr.c
+    ${BACNET_BASE}/src/bacnet/bacapp.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacdest.c
+    ${BACNET_BASE}/src/bacnet/bacdevobjpropref.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/baclog.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/bactext.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/datetime.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_BASE}/src/bacnet/hostnport.c
+    ${BACNET_BASE}/src/bacnet/lighting.c
+    ${BACNET_BASE}/src/bacnet/proplist.c
+    ${BACNET_BASE}/src/bacnet/shed_level.c
+    ${BACNET_BASE}/src/bacnet/timer_value.c
+    ${BACNET_BASE}/src/bacnet/timestamp.c
+    ${BACNET_BASE}/src/bacnet/wp.c
+    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
+    ${BACNET_BASE}/src/bacnet/bactimevalue.c
+    ${BACNET_BASE}/src/bacnet/dailyschedule.c
+    ${BACNET_BASE}/src/bacnet/calendar_entry.c
+    ${BACNET_BASE}/src/bacnet/special_event.c
+    ${BACNET_BASE}/src/bacnet/channel_value.c
+    ${BACNET_BASE}/src/bacnet/secure_connect.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/basic/object/access_point/CMakeLists.txt
+++ b/zephyr/tests/bacnet/basic/object/access_point/CMakeLists.txt
@@ -25,47 +25,40 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${BACNET_BASE}/src/bacnet/authentication_factor.c
     ${BACNET_BASE}/src/bacnet/basic/object/access_point.c
+    ${BACNET_BASE}/src/bacnet/access_rule.c
+    ${BACNET_BASE}/src/bacnet/authentication_factor.c
     ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
-    )
-
-  get_filename_component(BACNET_OBJECT_SRC ${BACNET_SRC_PATH} PATH)
-  get_filename_component(BACNET_BASIC_SRC ${BACNET_OBJECT_SRC} PATH)
-  get_filename_component(BACNET_SRC ${BACNET_BASIC_SRC} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/access_rule.c
-    ${BACNET_SRC}/bacaction.c
-    ${BACNET_SRC}/bacaddr.c
-    ${BACNET_SRC}/bacapp.c
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacdest.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/baclog.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/channel_value.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/basic/sys/days.c
-    ${BACNET_SRC}/bacdevobjpropref.c
-    ${BACNET_SRC}/bactext.c
-    ${BACNET_SRC}/indtext.c
-    ${BACNET_SRC}/lighting.c
-    ${BACNET_SRC}/proplist.c
-    ${BACNET_SRC}/shed_level.c
-    ${BACNET_SRC}/timer_value.c
-    ${BACNET_SRC}/hostnport.c
-    ${BACNET_SRC}/dailyschedule.c
-    ${BACNET_SRC}/weeklyschedule.c
-    ${BACNET_SRC}/calendar_entry.c
-    ${BACNET_SRC}/special_event.c
-    ${BACNET_SRC}/basic/sys/bigend.c
-    ${BACNET_SRC}/bactimevalue.c
-    ${BACNET_SRC}/secure_connect.c
-    ${BACNET_SRC}/wp.c
+    ${BACNET_BASE}/src/bacnet/bacaction.c
+    ${BACNET_BASE}/src/bacnet/bacaddr.c
+    ${BACNET_BASE}/src/bacnet/bacapp.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacdest.c
+    ${BACNET_BASE}/src/bacnet/bacdevobjpropref.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/baclog.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/bactext.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/datetime.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_BASE}/src/bacnet/hostnport.c
+    ${BACNET_BASE}/src/bacnet/lighting.c
+    ${BACNET_BASE}/src/bacnet/proplist.c
+    ${BACNET_BASE}/src/bacnet/shed_level.c
+    ${BACNET_BASE}/src/bacnet/timer_value.c
+    ${BACNET_BASE}/src/bacnet/timestamp.c
+    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
+    ${BACNET_BASE}/src/bacnet/bactimevalue.c
+    ${BACNET_BASE}/src/bacnet/dailyschedule.c
+    ${BACNET_BASE}/src/bacnet/calendar_entry.c
+    ${BACNET_BASE}/src/bacnet/special_event.c
+    ${BACNET_BASE}/src/bacnet/channel_value.c
+    ${BACNET_BASE}/src/bacnet/secure_connect.c
+    ${BACNET_BASE}/src/bacnet/wp.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/basic/object/access_rights/CMakeLists.txt
+++ b/zephyr/tests/bacnet/basic/object/access_rights/CMakeLists.txt
@@ -29,49 +29,42 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH TEST_OBJECT_INCLUDE $ENV{ZEPHYR_BASE} ${TEST_OBJECT_SRC})
   list(APPEND INCLUDE ${BACNET_INCLUDE} ${TEST_OBJECT_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${TEST_OBJECT_SRC}/property_test.c
     ${BACNET_BASE}/src/bacnet/basic/object/access_rights.c
-    ${BACNET_BASE}/src/bacnet/property.c
+    ${BACNET_BASE}/src/bacnet/access_rule.c
     ${BACNET_BASE}/src/bacnet/authentication_factor.c
     ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
-    )
-
-  get_filename_component(BACNET_OBJECT_SRC ${BACNET_SRC_PATH} PATH)
-  get_filename_component(BACNET_BASIC_SRC ${BACNET_OBJECT_SRC} PATH)
-  get_filename_component(BACNET_SRC ${BACNET_BASIC_SRC} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/access_rule.c
-    ${BACNET_SRC}/bacaction.c
-    ${BACNET_SRC}/bacaddr.c
-    ${BACNET_SRC}/bacapp.c
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacdest.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/baclog.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/channel_value.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/basic/sys/days.c
-    ${BACNET_SRC}/bacdevobjpropref.c
-    ${BACNET_SRC}/bactext.c
-    ${BACNET_SRC}/indtext.c
-    ${BACNET_SRC}/lighting.c
-    ${BACNET_SRC}/proplist.c
-    ${BACNET_SRC}/wp.c
-    ${BACNET_SRC}/shed_level.c
-    ${BACNET_SRC}/timer_value.c
-    ${BACNET_SRC}/hostnport.c
-    ${BACNET_SRC}/dailyschedule.c
-    ${BACNET_SRC}/weeklyschedule.c
-    ${BACNET_SRC}/calendar_entry.c
-    ${BACNET_SRC}/special_event.c
-    ${BACNET_SRC}/basic/sys/bigend.c
-    ${BACNET_SRC}/bactimevalue.c
-    ${BACNET_SRC}/secure_connect.c
+    ${BACNET_BASE}/src/bacnet/bacaction.c
+    ${BACNET_BASE}/src/bacnet/bacaddr.c
+    ${BACNET_BASE}/src/bacnet/bacapp.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacdest.c
+    ${BACNET_BASE}/src/bacnet/bacdevobjpropref.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/baclog.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/bactext.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/datetime.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_BASE}/src/bacnet/hostnport.c
+    ${BACNET_BASE}/src/bacnet/lighting.c
+    ${BACNET_BASE}/src/bacnet/property.c
+    ${BACNET_BASE}/src/bacnet/proplist.c
+    ${BACNET_BASE}/src/bacnet/shed_level.c
+    ${BACNET_BASE}/src/bacnet/timer_value.c
+    ${BACNET_BASE}/src/bacnet/timestamp.c
+    ${BACNET_BASE}/src/bacnet/wp.c
+    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
+    ${BACNET_BASE}/src/bacnet/bactimevalue.c
+    ${BACNET_BASE}/src/bacnet/dailyschedule.c
+    ${BACNET_BASE}/src/bacnet/calendar_entry.c
+    ${BACNET_BASE}/src/bacnet/special_event.c
+    ${BACNET_BASE}/src/bacnet/channel_value.c
+    ${BACNET_BASE}/src/bacnet/secure_connect.c
+    ${BACNET_TEST_PATH}/src/main.c
+    ${BACNET_BASE}/test/bacnet/basic/object/test/property_test.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/basic/object/access_user/CMakeLists.txt
+++ b/zephyr/tests/bacnet/basic/object/access_user/CMakeLists.txt
@@ -25,47 +25,40 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
     ${BACNET_BASE}/src/bacnet/basic/object/access_user.c
+    ${BACNET_BASE}/src/bacnet/access_rule.c
     ${BACNET_BASE}/src/bacnet/authentication_factor.c
     ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
-    )
-
-  get_filename_component(BACNET_OBJECT_SRC ${BACNET_SRC_PATH} PATH)
-  get_filename_component(BACNET_BASIC_SRC ${BACNET_OBJECT_SRC} PATH)
-  get_filename_component(BACNET_SRC ${BACNET_BASIC_SRC} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/access_rule.c
-    ${BACNET_SRC}/bacaction.c
-    ${BACNET_SRC}/bacaddr.c
-    ${BACNET_SRC}/bacapp.c
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacdest.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/baclog.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/channel_value.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/basic/sys/days.c
-    ${BACNET_SRC}/bacdevobjpropref.c
-    ${BACNET_SRC}/bactext.c
-    ${BACNET_SRC}/indtext.c
-    ${BACNET_SRC}/lighting.c
-    ${BACNET_SRC}/proplist.c
-    ${BACNET_SRC}/wp.c
-    ${BACNET_SRC}/shed_level.c
-    ${BACNET_SRC}/timer_value.c
-    ${BACNET_SRC}/hostnport.c
-    ${BACNET_SRC}/dailyschedule.c
-    ${BACNET_SRC}/weeklyschedule.c
-    ${BACNET_SRC}/calendar_entry.c
-    ${BACNET_SRC}/special_event.c
-    ${BACNET_SRC}/basic/sys/bigend.c
-    ${BACNET_SRC}/bactimevalue.c
-    ${BACNET_SRC}/secure_connect.c
+    ${BACNET_BASE}/src/bacnet/bacaction.c
+    ${BACNET_BASE}/src/bacnet/bacaddr.c
+    ${BACNET_BASE}/src/bacnet/bacapp.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacdest.c
+    ${BACNET_BASE}/src/bacnet/bacdevobjpropref.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/baclog.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/bactext.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/datetime.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_BASE}/src/bacnet/hostnport.c
+    ${BACNET_BASE}/src/bacnet/lighting.c
+    ${BACNET_BASE}/src/bacnet/proplist.c
+    ${BACNET_BASE}/src/bacnet/shed_level.c
+    ${BACNET_BASE}/src/bacnet/timer_value.c
+    ${BACNET_BASE}/src/bacnet/timestamp.c
+    ${BACNET_BASE}/src/bacnet/wp.c
+    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
+    ${BACNET_BASE}/src/bacnet/bactimevalue.c
+    ${BACNET_BASE}/src/bacnet/dailyschedule.c
+    ${BACNET_BASE}/src/bacnet/calendar_entry.c
+    ${BACNET_BASE}/src/bacnet/special_event.c
+    ${BACNET_BASE}/src/bacnet/channel_value.c
+    ${BACNET_BASE}/src/bacnet/secure_connect.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/basic/object/access_zone/CMakeLists.txt
+++ b/zephyr/tests/bacnet/basic/object/access_zone/CMakeLists.txt
@@ -25,50 +25,43 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${BACNET_BASE}/src/bacnet/authentication_factor.c
-    ${BACNET_BASE}/src/bacnet/assigned_access_rights.c
-    ${BACNET_BASE}/src/bacnet/credential_authentication_factor.c
     ${BACNET_BASE}/src/bacnet/basic/object/access_credential.c
-    ${BACNET_BASE}/src/bacnet/basic/object/access_zone.c
+    ${BACNET_BASE}/src/bacnet/access_rule.c
+    ${BACNET_BASE}/src/bacnet/authentication_factor.c
     ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
-    )
-
-  get_filename_component(BACNET_OBJECT_SRC ${BACNET_SRC_PATH} PATH)
-  get_filename_component(BACNET_BASIC_SRC ${BACNET_OBJECT_SRC} PATH)
-  get_filename_component(BACNET_SRC ${BACNET_BASIC_SRC} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/access_rule.c
-    ${BACNET_SRC}/bacaction.c
-    ${BACNET_SRC}/bacaddr.c
-    ${BACNET_SRC}/bacapp.c
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacdest.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/baclog.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/channel_value.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/basic/sys/days.c
-    ${BACNET_SRC}/bacdevobjpropref.c
-    ${BACNET_SRC}/bactext.c
-    ${BACNET_SRC}/indtext.c
-    ${BACNET_SRC}/lighting.c
-    ${BACNET_SRC}/proplist.c
-    ${BACNET_SRC}/wp.c
-    ${BACNET_SRC}/shed_level.c
-    ${BACNET_SRC}/timer_value.c
-    ${BACNET_SRC}/hostnport.c
-    ${BACNET_SRC}/dailyschedule.c
-    ${BACNET_SRC}/weeklyschedule.c
-    ${BACNET_SRC}/calendar_entry.c
-    ${BACNET_SRC}/special_event.c
-    ${BACNET_SRC}/basic/sys/bigend.c
-    ${BACNET_SRC}/bactimevalue.c
-    ${BACNET_SRC}/secure_connect.c
+    ${BACNET_BASE}/src/bacnet/assigned_access_rights.c
+    ${BACNET_BASE}/src/bacnet/bacaction.c
+    ${BACNET_BASE}/src/bacnet/bacaddr.c
+    ${BACNET_BASE}/src/bacnet/bacapp.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacdest.c
+    ${BACNET_BASE}/src/bacnet/bacdevobjpropref.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/baclog.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/bactext.c
+    ${BACNET_BASE}/src/bacnet/basic/object/access_zone.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/credential_authentication_factor.c
+    ${BACNET_BASE}/src/bacnet/datetime.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_BASE}/src/bacnet/hostnport.c
+    ${BACNET_BASE}/src/bacnet/lighting.c
+    ${BACNET_BASE}/src/bacnet/proplist.c
+    ${BACNET_BASE}/src/bacnet/shed_level.c
+    ${BACNET_BASE}/src/bacnet/timer_value.c
+    ${BACNET_BASE}/src/bacnet/timestamp.c
+    ${BACNET_BASE}/src/bacnet/wp.c
+    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
+    ${BACNET_BASE}/src/bacnet/bactimevalue.c
+    ${BACNET_BASE}/src/bacnet/dailyschedule.c
+    ${BACNET_BASE}/src/bacnet/calendar_entry.c
+    ${BACNET_BASE}/src/bacnet/special_event.c
+    ${BACNET_BASE}/src/bacnet/channel_value.c
+    ${BACNET_BASE}/src/bacnet/secure_connect.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/basic/object/ai/CMakeLists.txt
+++ b/zephyr/tests/bacnet/basic/object/ai/CMakeLists.txt
@@ -29,54 +29,47 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH TEST_OBJECT_INCLUDE $ENV{ZEPHYR_BASE} ${TEST_OBJECT_SRC})
   list(APPEND INCLUDE ${BACNET_INCLUDE} ${TEST_OBJECT_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${BACNET_TEST_PATH}/stubs.c
-    ${TEST_OBJECT_SRC}/property_test.c
     ${BACNET_BASE}/src/bacnet/basic/object/ai.c
+    ${BACNET_BASE}/src/bacnet/access_rule.c
     ${BACNET_BASE}/src/bacnet/authentication_factor.c
     ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
+    ${BACNET_BASE}/src/bacnet/bacaction.c
+    ${BACNET_BASE}/src/bacnet/bacaddr.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacdest.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/baclog.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/bactext.c
+    ${BACNET_BASE}/src/bacnet/bacapp.c
+    ${BACNET_BASE}/src/bacnet/bacdevobjpropref.c
+    ${BACNET_BASE}/src/bacnet/cov.c
+    ${BACNET_BASE}/src/bacnet/datetime.c
+    ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_BASE}/src/bacnet/hostnport.c
+    ${BACNET_BASE}/src/bacnet/lighting.c
+    ${BACNET_BASE}/src/bacnet/proplist.c
+    ${BACNET_BASE}/src/bacnet/shed_level.c
+    ${BACNET_BASE}/src/bacnet/timer_value.c
+    ${BACNET_BASE}/src/bacnet/timestamp.c
+    ${BACNET_BASE}/src/bacnet/memcopy.c
+    ${BACNET_BASE}/src/bacnet/wp.c
+    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
+    ${BACNET_BASE}/src/bacnet/bactimevalue.c
+    ${BACNET_BASE}/src/bacnet/dailyschedule.c
+    ${BACNET_BASE}/src/bacnet/calendar_entry.c
+    ${BACNET_BASE}/src/bacnet/special_event.c
+    ${BACNET_BASE}/src/bacnet/channel_value.c
+    ${BACNET_BASE}/src/bacnet/secure_connect.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/debug.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/keylist.c
+    ${BACNET_TEST_PATH}/src/main.c
+    ${BACNET_TEST_PATH}/stubs.c
+    ${BACNET_BASE}/test/bacnet/basic/object/test/property_test.c
     )
-
-  get_filename_component(BACNET_OBJECT_SRC ${BACNET_SRC_PATH} PATH)
-  get_filename_component(BACNET_BASIC_SRC ${BACNET_OBJECT_SRC} PATH)
-  get_filename_component(BACNET_SRC ${BACNET_BASIC_SRC} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/access_rule.c
-    ${BACNET_SRC}/bacaction.c
-    ${BACNET_SRC}/bacaddr.c
-    ${BACNET_SRC}/bacapp.c
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacdest.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/baclog.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/bactext.c
-    ${BACNET_SRC}/cov.c
-    ${BACNET_SRC}/channel_value.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/bacdevobjpropref.c
-    ${BACNET_SRC}/indtext.c
-    ${BACNET_SRC}/lighting.c
-    ${BACNET_SRC}/proplist.c
-    ${BACNET_SRC}/wp.c
-    ${BACNET_SRC}/memcopy.c
-    ${BACNET_SRC}/shed_level.c
-    ${BACNET_SRC}/timer_value.c
-    ${BACNET_SRC}/hostnport.c
-    ${BACNET_SRC}/dailyschedule.c
-    ${BACNET_SRC}/weeklyschedule.c
-    ${BACNET_SRC}/bactimevalue.c
-    ${BACNET_SRC}/calendar_entry.c
-    ${BACNET_SRC}/special_event.c
-    ${BACNET_SRC}/basic/sys/bigend.c
-    ${BACNET_SRC}/basic/sys/days.c
-    ${BACNET_SRC}/basic/sys/debug.c
-    ${BACNET_SRC}/basic/sys/keylist.c
-    ${BACNET_SRC}/secure_connect.c
-  )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")
   find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/zephyr/tests/bacnet/basic/object/ao/CMakeLists.txt
+++ b/zephyr/tests/bacnet/basic/object/ao/CMakeLists.txt
@@ -29,53 +29,45 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH TEST_OBJECT_INCLUDE $ENV{ZEPHYR_BASE} ${TEST_OBJECT_SRC})
   list(APPEND INCLUDE ${BACNET_INCLUDE} ${TEST_OBJECT_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${TEST_OBJECT_SRC}/property_test.c
-    ${BACNET_BASE}/src/bacnet/authentication_factor.c
-    ${BACNET_BASE}/src/bacnet/memcopy.c
-    ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
     ${BACNET_BASE}/src/bacnet/basic/object/ao.c
+    ${BACNET_BASE}/src/bacnet/access_rule.c
+    ${BACNET_BASE}/src/bacnet/authentication_factor.c
+    ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
+    ${BACNET_BASE}/src/bacnet/bacaction.c
+    ${BACNET_BASE}/src/bacnet/bacaddr.c
+    ${BACNET_BASE}/src/bacnet/bacapp.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacdest.c
+    ${BACNET_BASE}/src/bacnet/bacdevobjpropref.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/baclog.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/bactext.c
+    ${BACNET_BASE}/src/bacnet/cov.c
+    ${BACNET_BASE}/src/bacnet/datetime.c
+    ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_BASE}/src/bacnet/hostnport.c
+    ${BACNET_BASE}/src/bacnet/lighting.c
+    ${BACNET_BASE}/src/bacnet/proplist.c
+    ${BACNET_BASE}/src/bacnet/memcopy.c
+    ${BACNET_BASE}/src/bacnet/shed_level.c
+    ${BACNET_BASE}/src/bacnet/timer_value.c
+    ${BACNET_BASE}/src/bacnet/timestamp.c
+    ${BACNET_BASE}/src/bacnet/wp.c
+    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
+    ${BACNET_BASE}/src/bacnet/bactimevalue.c
+    ${BACNET_BASE}/src/bacnet/dailyschedule.c
+    ${BACNET_BASE}/src/bacnet/calendar_entry.c
+    ${BACNET_BASE}/src/bacnet/special_event.c
+    ${BACNET_BASE}/src/bacnet/channel_value.c
+    ${BACNET_BASE}/src/bacnet/secure_connect.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/keylist.c
+    ${BACNET_TEST_PATH}/src/main.c
+    ${BACNET_BASE}/test/bacnet/basic/object/test/property_test.c
     )
-
-  get_filename_component(BACNET_OBJECT_SRC ${BACNET_SRC_PATH} PATH)
-  get_filename_component(BACNET_BASIC_SRC ${BACNET_OBJECT_SRC} PATH)
-  get_filename_component(BACNET_SRC ${BACNET_BASIC_SRC} PATH)
-  list(APPEND SOURCES
-  ${BACNET_SRC}/access_rule.c
-  ${BACNET_SRC}/bacaction.c
-  ${BACNET_SRC}/bacaddr.c
-  ${BACNET_SRC}/bacapp.c
-  ${BACNET_SRC}/bacdcode.c
-  ${BACNET_SRC}/bacdest.c
-  ${BACNET_SRC}/bacint.c
-  ${BACNET_SRC}/baclog.c
-  ${BACNET_SRC}/bacreal.c
-  ${BACNET_SRC}/bacstr.c
-  ${BACNET_SRC}/datetime.c
-  ${BACNET_SRC}/bacdevobjpropref.c
-  ${BACNET_SRC}/bactext.c
-  ${BACNET_SRC}/channel_value.c
-  ${BACNET_SRC}/cov.c
-  ${BACNET_SRC}/indtext.c
-  ${BACNET_SRC}/lighting.c
-  ${BACNET_SRC}/proplist.c
-  ${BACNET_SRC}/timestamp.c
-  ${BACNET_SRC}/wp.c
-  ${BACNET_SRC}/shed_level.c
-  ${BACNET_SRC}/timer_value.c
-  ${BACNET_SRC}/hostnport.c
-  ${BACNET_SRC}/dailyschedule.c
-  ${BACNET_SRC}/weeklyschedule.c
-  ${BACNET_SRC}/calendar_entry.c
-  ${BACNET_SRC}/special_event.c
-  ${BACNET_SRC}/bactimevalue.c
-  ${BACNET_SRC}/basic/sys/bigend.c
-  ${BACNET_SRC}/basic/sys/days.c
-  ${BACNET_SRC}/basic/sys/debug.c
-  ${BACNET_SRC}/basic/sys/keylist.c
-  ${BACNET_SRC}/secure_connect.c
-  )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")
   find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/zephyr/tests/bacnet/basic/object/av/CMakeLists.txt
+++ b/zephyr/tests/bacnet/basic/object/av/CMakeLists.txt
@@ -29,54 +29,47 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH TEST_OBJECT_INCLUDE $ENV{ZEPHYR_BASE} ${TEST_OBJECT_SRC})
   list(APPEND INCLUDE ${BACNET_INCLUDE} ${TEST_OBJECT_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
+    ${BACNET_BASE}/src/bacnet/basic/object/av.c
+    ${BACNET_BASE}/src/bacnet/access_rule.c
+    ${BACNET_BASE}/src/bacnet/authentication_factor.c
+    ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
+    ${BACNET_BASE}/src/bacnet/bacaction.c
+    ${BACNET_BASE}/src/bacnet/bacaddr.c
+    ${BACNET_BASE}/src/bacnet/bacapp.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacdest.c
+    ${BACNET_BASE}/src/bacnet/bacdevobjpropref.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/baclog.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/bactext.c
+    ${BACNET_BASE}/src/bacnet/cov.c
+    ${BACNET_BASE}/src/bacnet/datetime.c
+    ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_BASE}/src/bacnet/hostnport.c
+    ${BACNET_BASE}/src/bacnet/lighting.c
+    ${BACNET_BASE}/src/bacnet/proplist.c
+    ${BACNET_BASE}/src/bacnet/shed_level.c
+    ${BACNET_BASE}/src/bacnet/timer_value.c
+    ${BACNET_BASE}/src/bacnet/timestamp.c
+    ${BACNET_BASE}/src/bacnet/memcopy.c
+    ${BACNET_BASE}/src/bacnet/wp.c
+    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
+    ${BACNET_BASE}/src/bacnet/bactimevalue.c
+    ${BACNET_BASE}/src/bacnet/dailyschedule.c
+    ${BACNET_BASE}/src/bacnet/calendar_entry.c
+    ${BACNET_BASE}/src/bacnet/special_event.c
+    ${BACNET_BASE}/src/bacnet/channel_value.c
+    ${BACNET_BASE}/src/bacnet/secure_connect.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/debug.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/keylist.c
     ${BACNET_TEST_PATH}/src/main.c
     ${BACNET_TEST_PATH}/stubs.c
-    ${TEST_OBJECT_SRC}/property_test.c
-    ${BACNET_BASE}/src/bacnet/authentication_factor.c
-    ${BACNET_BASE}/src/bacnet/basic/object/av.c
-    ${BACNET_BASE}/src/bacnet/memcopy.c
-    ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
+    ${BACNET_BASE}/test/bacnet/basic/object/test/property_test.c
     )
-
-  get_filename_component(BACNET_OBJECT_SRC ${BACNET_SRC_PATH} PATH)
-  get_filename_component(BACNET_BASIC_SRC ${BACNET_OBJECT_SRC} PATH)
-  get_filename_component(BACNET_SRC ${BACNET_BASIC_SRC} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/access_rule.c
-    ${BACNET_SRC}/bacaction.c
-    ${BACNET_SRC}/bacaddr.c
-    ${BACNET_SRC}/bacapp.c
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacdest.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/baclog.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/channel_value.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/bacdevobjpropref.c
-    ${BACNET_SRC}/bactext.c
-    ${BACNET_SRC}/cov.c
-    ${BACNET_SRC}/indtext.c
-    ${BACNET_SRC}/lighting.c
-    ${BACNET_SRC}/proplist.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/wp.c
-    ${BACNET_SRC}/shed_level.c
-    ${BACNET_SRC}/timer_value.c
-    ${BACNET_SRC}/hostnport.c
-    ${BACNET_SRC}/dailyschedule.c
-    ${BACNET_SRC}/weeklyschedule.c
-    ${BACNET_SRC}/calendar_entry.c
-    ${BACNET_SRC}/special_event.c
-    ${BACNET_SRC}/bactimevalue.c
-    ${BACNET_SRC}/basic/sys/bigend.c
-    ${BACNET_SRC}/basic/sys/days.c
-    ${BACNET_SRC}/basic/sys/debug.c
-    ${BACNET_SRC}/basic/sys/keylist.c
-    ${BACNET_SRC}/secure_connect.c
-  )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")
   find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/zephyr/tests/bacnet/basic/object/bi/CMakeLists.txt
+++ b/zephyr/tests/bacnet/basic/object/bi/CMakeLists.txt
@@ -29,52 +29,46 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH TEST_OBJECT_INCLUDE $ENV{ZEPHYR_BASE} ${TEST_OBJECT_SRC})
   list(APPEND INCLUDE ${BACNET_INCLUDE} ${TEST_OBJECT_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${TEST_OBJECT_SRC}/property_test.c
-    ${BACNET_BASE}/src/bacnet/authentication_factor.c
     ${BACNET_BASE}/src/bacnet/basic/object/bi.c
-    ${BACNET_BASE}/src/bacnet/memcopy.c
+    ${BACNET_BASE}/src/bacnet/access_rule.c
+    ${BACNET_BASE}/src/bacnet/authentication_factor.c
     ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
-    )
-
-  get_filename_component(BACNET_OBJECT_SRC ${BACNET_SRC_PATH} PATH)
-  get_filename_component(BACNET_BASIC_SRC ${BACNET_OBJECT_SRC} PATH)
-  get_filename_component(BACNET_SRC ${BACNET_BASIC_SRC} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/access_rule.c
-    ${BACNET_SRC}/bacaction.c
-    ${BACNET_SRC}/bacaddr.c
-    ${BACNET_SRC}/bacapp.c
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacdest.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/baclog.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/channel_value.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/bacdevobjpropref.c
-    ${BACNET_SRC}/bactext.c
-    ${BACNET_SRC}/cov.c
-    ${BACNET_SRC}/indtext.c
-    ${BACNET_SRC}/lighting.c
-    ${BACNET_SRC}/proplist.c
-    ${BACNET_SRC}/wp.c
-    ${BACNET_SRC}/shed_level.c
-    ${BACNET_SRC}/timer_value.c
-    ${BACNET_SRC}/hostnport.c
-    ${BACNET_SRC}/dailyschedule.c
-    ${BACNET_SRC}/weeklyschedule.c
-    ${BACNET_SRC}/calendar_entry.c
-    ${BACNET_SRC}/special_event.c
-    ${BACNET_SRC}/bactimevalue.c
-    ${BACNET_SRC}/basic/sys/bigend.c
-    ${BACNET_SRC}/basic/sys/days.c
-    ${BACNET_SRC}/basic/sys/debug.c
-    ${BACNET_SRC}/basic/sys/keylist.c
-    ${BACNET_SRC}/secure_connect.c
+    ${BACNET_BASE}/src/bacnet/bacaction.c
+    ${BACNET_BASE}/src/bacnet/bacaddr.c
+    ${BACNET_BASE}/src/bacnet/bacapp.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacdest.c
+    ${BACNET_BASE}/src/bacnet/bacdevobjpropref.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/baclog.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/bactext.c
+    ${BACNET_BASE}/src/bacnet/cov.c
+    ${BACNET_BASE}/src/bacnet/datetime.c
+    ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_BASE}/src/bacnet/hostnport.c
+    ${BACNET_BASE}/src/bacnet/lighting.c
+    ${BACNET_BASE}/src/bacnet/proplist.c
+    ${BACNET_BASE}/src/bacnet/shed_level.c
+    ${BACNET_BASE}/src/bacnet/timer_value.c
+    ${BACNET_BASE}/src/bacnet/timestamp.c
+    ${BACNET_BASE}/src/bacnet/memcopy.c
+    ${BACNET_BASE}/src/bacnet/wp.c
+    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
+    ${BACNET_BASE}/src/bacnet/bactimevalue.c
+    ${BACNET_BASE}/src/bacnet/dailyschedule.c
+    ${BACNET_BASE}/src/bacnet/calendar_entry.c
+    ${BACNET_BASE}/src/bacnet/special_event.c
+    ${BACNET_BASE}/src/bacnet/channel_value.c
+    ${BACNET_BASE}/src/bacnet/secure_connect.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/debug.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/keylist.c
+    ${BACNET_TEST_PATH}/src/main.c
+    ${BACNET_TEST_PATH}/stubs.c
+    ${BACNET_BASE}/test/bacnet/basic/object/test/property_test.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/basic/object/bo/CMakeLists.txt
+++ b/zephyr/tests/bacnet/basic/object/bo/CMakeLists.txt
@@ -29,53 +29,46 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH TEST_OBJECT_INCLUDE $ENV{ZEPHYR_BASE} ${TEST_OBJECT_SRC})
   list(APPEND INCLUDE ${BACNET_INCLUDE} ${TEST_OBJECT_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${TEST_OBJECT_SRC}/property_test.c
-    ${BACNET_BASE}/src/bacnet/authentication_factor.c
-    ${BACNET_BASE}/src/bacnet/memcopy.c
-    ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
     ${BACNET_BASE}/src/bacnet/basic/object/bo.c
+    ${BACNET_BASE}/src/bacnet/access_rule.c
+    ${BACNET_BASE}/src/bacnet/authentication_factor.c
+    ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
+    ${BACNET_BASE}/src/bacnet/bacaction.c
+    ${BACNET_BASE}/src/bacnet/bacaddr.c
+    ${BACNET_BASE}/src/bacnet/bacapp.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacdest.c
+    ${BACNET_BASE}/src/bacnet/bacdevobjpropref.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/baclog.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/bactext.c
+    ${BACNET_BASE}/src/bacnet/cov.c
+    ${BACNET_BASE}/src/bacnet/datetime.c
+    ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_BASE}/src/bacnet/hostnport.c
+    ${BACNET_BASE}/src/bacnet/lighting.c
+    ${BACNET_BASE}/src/bacnet/proplist.c
+    ${BACNET_BASE}/src/bacnet/memcopy.c
+    ${BACNET_BASE}/src/bacnet/shed_level.c
+    ${BACNET_BASE}/src/bacnet/timer_value.c
+    ${BACNET_BASE}/src/bacnet/timestamp.c
+    ${BACNET_BASE}/src/bacnet/wp.c
+    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
+    ${BACNET_BASE}/src/bacnet/bactimevalue.c
+    ${BACNET_BASE}/src/bacnet/dailyschedule.c
+    ${BACNET_BASE}/src/bacnet/calendar_entry.c
+    ${BACNET_BASE}/src/bacnet/special_event.c
+    ${BACNET_BASE}/src/bacnet/channel_value.c
+    ${BACNET_BASE}/src/bacnet/secure_connect.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/debug.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/keylist.c
+    ${BACNET_TEST_PATH}/src/main.c
+    ${BACNET_BASE}/test/bacnet/basic/object/test/property_test.c
     )
-
-  get_filename_component(BACNET_OBJECT_SRC ${BACNET_SRC_PATH} PATH)
-  get_filename_component(BACNET_BASIC_SRC ${BACNET_OBJECT_SRC} PATH)
-  get_filename_component(BACNET_SRC ${BACNET_BASIC_SRC} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/access_rule.c
-    ${BACNET_SRC}/bacaction.c
-    ${BACNET_SRC}/bacaddr.c
-    ${BACNET_SRC}/bacapp.c
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacdest.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/baclog.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/channel_value.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/bacdevobjpropref.c
-    ${BACNET_SRC}/bactext.c
-    ${BACNET_SRC}/cov.c
-    ${BACNET_SRC}/indtext.c
-    ${BACNET_SRC}/lighting.c
-    ${BACNET_SRC}/proplist.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/wp.c
-    ${BACNET_SRC}/shed_level.c
-    ${BACNET_SRC}/timer_value.c
-    ${BACNET_SRC}/hostnport.c
-    ${BACNET_SRC}/dailyschedule.c
-    ${BACNET_SRC}/weeklyschedule.c
-    ${BACNET_SRC}/calendar_entry.c
-    ${BACNET_SRC}/special_event.c
-    ${BACNET_SRC}/bactimevalue.c
-    ${BACNET_SRC}/basic/sys/bigend.c
-    ${BACNET_SRC}/basic/sys/days.c
-    ${BACNET_SRC}/basic/sys/debug.c
-    ${BACNET_SRC}/basic/sys/keylist.c
-    ${BACNET_SRC}/secure_connect.c
-  )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")
   find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/zephyr/tests/bacnet/basic/object/bv/CMakeLists.txt
+++ b/zephyr/tests/bacnet/basic/object/bv/CMakeLists.txt
@@ -29,52 +29,46 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH TEST_OBJECT_INCLUDE $ENV{ZEPHYR_BASE} ${TEST_OBJECT_SRC})
   list(APPEND INCLUDE ${BACNET_INCLUDE} ${TEST_OBJECT_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${TEST_OBJECT_SRC}/property_test.c
-    ${BACNET_BASE}/src/bacnet/authentication_factor.c
     ${BACNET_BASE}/src/bacnet/basic/object/bv.c
+    ${BACNET_BASE}/src/bacnet/access_rule.c
+    ${BACNET_BASE}/src/bacnet/authentication_factor.c
     ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
+    ${BACNET_BASE}/src/bacnet/bacaction.c
+    ${BACNET_BASE}/src/bacnet/bacaddr.c
+    ${BACNET_BASE}/src/bacnet/bacapp.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacdest.c
+    ${BACNET_BASE}/src/bacnet/bacdevobjpropref.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/baclog.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/bactext.c
+    ${BACNET_BASE}/src/bacnet/cov.c
+    ${BACNET_BASE}/src/bacnet/datetime.c
+    ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_BASE}/src/bacnet/hostnport.c
+    ${BACNET_BASE}/src/bacnet/lighting.c
+    ${BACNET_BASE}/src/bacnet/proplist.c
+    ${BACNET_BASE}/src/bacnet/shed_level.c
+    ${BACNET_BASE}/src/bacnet/timer_value.c
+    ${BACNET_BASE}/src/bacnet/timestamp.c
+    ${BACNET_BASE}/src/bacnet/wp.c
+    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
+    ${BACNET_BASE}/src/bacnet/bactimevalue.c
+    ${BACNET_BASE}/src/bacnet/dailyschedule.c
+    ${BACNET_BASE}/src/bacnet/calendar_entry.c
+    ${BACNET_BASE}/src/bacnet/special_event.c
+    ${BACNET_BASE}/src/bacnet/channel_value.c
+    ${BACNET_BASE}/src/bacnet/secure_connect.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/debug.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/keylist.c
+    ${BACNET_TEST_PATH}/src/main.c
+    ${BACNET_TEST_PATH}/stubs.c
+    ${BACNET_BASE}/test/bacnet/basic/object/test/property_test.c
     )
-
-  get_filename_component(BACNET_OBJECT_SRC ${BACNET_SRC_PATH} PATH)
-  get_filename_component(BACNET_BASIC_SRC ${BACNET_OBJECT_SRC} PATH)
-  get_filename_component(BACNET_SRC ${BACNET_BASIC_SRC} PATH)
-  list(APPEND SOURCES
-  ${BACNET_SRC}/access_rule.c
-  ${BACNET_SRC}/bacaction.c
-  ${BACNET_SRC}/bacaddr.c
-  ${BACNET_SRC}/bacapp.c
-  ${BACNET_SRC}/bacdcode.c
-  ${BACNET_SRC}/bacdest.c
-  ${BACNET_SRC}/bacint.c
-  ${BACNET_SRC}/baclog.c
-  ${BACNET_SRC}/bacreal.c
-  ${BACNET_SRC}/bacstr.c
-  ${BACNET_SRC}/channel_value.c
-  ${BACNET_SRC}/datetime.c
-  ${BACNET_SRC}/bacdevobjpropref.c
-  ${BACNET_SRC}/bactext.c
-  ${BACNET_SRC}/cov.c
-  ${BACNET_SRC}/indtext.c
-  ${BACNET_SRC}/lighting.c
-  ${BACNET_SRC}/proplist.c
-  ${BACNET_SRC}/timestamp.c
-  ${BACNET_SRC}/wp.c
-  ${BACNET_SRC}/shed_level.c
-  ${BACNET_SRC}/timer_value.c
-  ${BACNET_SRC}/hostnport.c
-  ${BACNET_SRC}/dailyschedule.c
-  ${BACNET_SRC}/weeklyschedule.c
-  ${BACNET_SRC}/calendar_entry.c
-  ${BACNET_SRC}/special_event.c
-  ${BACNET_SRC}/bactimevalue.c
-  ${BACNET_SRC}/basic/sys/bigend.c
-  ${BACNET_SRC}/basic/sys/days.c
-  ${BACNET_SRC}/basic/sys/debug.c
-  ${BACNET_SRC}/basic/sys/keylist.c
-  ${BACNET_SRC}/secure_connect.c
-  )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")
   find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/zephyr/tests/bacnet/basic/object/calendar/CMakeLists.txt
+++ b/zephyr/tests/bacnet/basic/object/calendar/CMakeLists.txt
@@ -26,52 +26,45 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
+    ${BACNET_BASE}/src/bacnet/basic/object/calendar.c
+    ${BACNET_BASE}/src/bacnet/access_rule.c
+    ${BACNET_BASE}/src/bacnet/authentication_factor.c
+    ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
+    ${BACNET_BASE}/src/bacnet/bacaction.c
+    ${BACNET_BASE}/src/bacnet/bacaddr.c
+    ${BACNET_BASE}/src/bacnet/bacapp.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacdest.c
+    ${BACNET_BASE}/src/bacnet/bacdevobjpropref.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/baclog.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/bactext.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/keylist.c
+    ${BACNET_BASE}/src/bacnet/cov.c
+    ${BACNET_BASE}/src/bacnet/datetime.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_BASE}/src/bacnet/hostnport.c
+    ${BACNET_BASE}/src/bacnet/lighting.c
+    ${BACNET_BASE}/src/bacnet/proplist.c
+    ${BACNET_BASE}/src/bacnet/shed_level.c
+    ${BACNET_BASE}/src/bacnet/timer_value.c
+    ${BACNET_BASE}/src/bacnet/timestamp.c
+    ${BACNET_BASE}/src/bacnet/memcopy.c
+    ${BACNET_BASE}/src/bacnet/wp.c
+    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
+    ${BACNET_BASE}/src/bacnet/calendar_entry.c
+    ${BACNET_BASE}/src/bacnet/special_event.c
+    ${BACNET_BASE}/src/bacnet/channel_value.c
+    ${BACNET_BASE}/src/bacnet/secure_connect.c
+    ${BACNET_BASE}/src/bacnet/bactimevalue.c
+    ${BACNET_BASE}/src/bacnet/dailyschedule.c
     ${BACNET_TEST_PATH}/src/main.c
     ${BACNET_TEST_PATH}/stubs.c
-    ${TEST_OBJECT_SRC}/device_mock.c
-    ${BACNET_BASE}/src/bacnet/basic/object/calendar.c
-    ${BACNET_BASE}/src/bacnet/authentication_factor.c
-    ${BACNET_BASE}/src/bacnet/memcopy.c
-    ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
-    ${BACNET_BASE}/src/bacnet/cov.c
-    )
-
-  get_filename_component(BACNET_OBJECT_SRC ${BACNET_SRC_PATH} PATH)
-  get_filename_component(BACNET_BASIC_SRC ${BACNET_OBJECT_SRC} PATH)
-  get_filename_component(BACNET_SRC ${BACNET_BASIC_SRC} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/access_rule.c
-    ${BACNET_SRC}/bacaction.c
-    ${BACNET_SRC}/bacaddr.c
-    ${BACNET_SRC}/bacapp.c
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacdest.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/baclog.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/channel_value.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/basic/sys/days.c
-    ${BACNET_SRC}/basic/sys/keylist.c
-    ${BACNET_SRC}/bacdevobjpropref.c
-    ${BACNET_SRC}/bactext.c
-    ${BACNET_SRC}/indtext.c
-    ${BACNET_SRC}/lighting.c
-    ${BACNET_SRC}/proplist.c
-    ${BACNET_SRC}/wp.c
-    ${BACNET_SRC}/shed_level.c
-    ${BACNET_SRC}/timer_value.c
-    ${BACNET_SRC}/hostnport.c
-    ${BACNET_SRC}/calendar_entry.c
-    ${BACNET_SRC}/dailyschedule.c
-    ${BACNET_SRC}/special_event.c
-    ${BACNET_SRC}/weeklyschedule.c
-    ${BACNET_SRC}/basic/sys/bigend.c
-    ${BACNET_SRC}/bactimevalue.c
-    ${BACNET_SRC}/secure_connect.c
+    ${BACNET_BASE}/test/bacnet/basic/object/test/device_mock.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/basic/object/color_object/CMakeLists.txt
+++ b/zephyr/tests/bacnet/basic/object/color_object/CMakeLists.txt
@@ -26,54 +26,47 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${TEST_OBJECT_SRC}/device_mock.c
     ${BACNET_BASE}/src/bacnet/basic/object/color_object.c
+    ${BACNET_BASE}/src/bacnet/access_rule.c
     ${BACNET_BASE}/src/bacnet/authentication_factor.c
-    ${BACNET_BASE}/src/bacnet/memcopy.c
-    ${BACNET_BASE}/src/bacnet/basic/sys/lighting_command.c
     ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
+    ${BACNET_BASE}/src/bacnet/bacaction.c
+    ${BACNET_BASE}/src/bacnet/bacaddr.c
+    ${BACNET_BASE}/src/bacnet/bacapp.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacdest.c
+    ${BACNET_BASE}/src/bacnet/bacdevobjpropref.c
+    ${BACNET_BASE}/src/bacnet/baclog.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/bactext.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
     ${BACNET_BASE}/src/bacnet/basic/sys/debug.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/keylist.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/lighting_command.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/linear.c
     ${BACNET_BASE}/src/bacnet/cov.c
-    )
-
-  get_filename_component(BACNET_OBJECT_SRC ${BACNET_SRC_PATH} PATH)
-  get_filename_component(BACNET_BASIC_SRC ${BACNET_OBJECT_SRC} PATH)
-  get_filename_component(BACNET_SRC ${BACNET_BASIC_SRC} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/access_rule.c
-    ${BACNET_SRC}/bacaction.c
-    ${BACNET_SRC}/bacaddr.c
-    ${BACNET_SRC}/bacapp.c
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacdest.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/baclog.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/channel_value.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/basic/sys/days.c
-    ${BACNET_SRC}/basic/sys/keylist.c
-    ${BACNET_SRC}/basic/sys/linear.c
-    ${BACNET_SRC}/bacdevobjpropref.c
-    ${BACNET_SRC}/bactext.c
-    ${BACNET_SRC}/indtext.c
-    ${BACNET_SRC}/lighting.c
-    ${BACNET_SRC}/shed_level.c
-    ${BACNET_SRC}/timer_value.c
-    ${BACNET_SRC}/hostnport.c
-    ${BACNET_SRC}/proplist.c
-    ${BACNET_SRC}/wp.c
-    ${BACNET_SRC}/dailyschedule.c
-    ${BACNET_SRC}/weeklyschedule.c
-    ${BACNET_SRC}/calendar_entry.c
-    ${BACNET_SRC}/special_event.c
-    ${BACNET_SRC}/basic/sys/bigend.c
-    ${BACNET_SRC}/bactimevalue.c
-    ${BACNET_SRC}/secure_connect.c
+    ${BACNET_BASE}/src/bacnet/datetime.c
+    ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_BASE}/src/bacnet/hostnport.c
+    ${BACNET_BASE}/src/bacnet/lighting.c
+    ${BACNET_BASE}/src/bacnet/proplist.c
+    ${BACNET_BASE}/src/bacnet/shed_level.c
+    ${BACNET_BASE}/src/bacnet/timer_value.c
+    ${BACNET_BASE}/src/bacnet/timestamp.c
+    ${BACNET_BASE}/src/bacnet/memcopy.c
+    ${BACNET_BASE}/src/bacnet/wp.c
+    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
+    ${BACNET_BASE}/src/bacnet/bactimevalue.c
+    ${BACNET_BASE}/src/bacnet/dailyschedule.c
+    ${BACNET_BASE}/src/bacnet/calendar_entry.c
+    ${BACNET_BASE}/src/bacnet/special_event.c
+    ${BACNET_BASE}/src/bacnet/channel_value.c
+    ${BACNET_BASE}/src/bacnet/secure_connect.c
+    ${BACNET_TEST_PATH}/src/main.c
+    ${BACNET_BASE}/test/bacnet/basic/object/test/device_mock.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/basic/object/color_temperature/CMakeLists.txt
+++ b/zephyr/tests/bacnet/basic/object/color_temperature/CMakeLists.txt
@@ -26,54 +26,47 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${TEST_OBJECT_SRC}/device_mock.c
-    ${BACNET_BASE}/src/bacnet/authentication_factor.c
     ${BACNET_BASE}/src/bacnet/basic/object/color_temperature.c
-    ${BACNET_BASE}/src/bacnet/memcopy.c
-    ${BACNET_BASE}/src/bacnet/basic/sys/lighting_command.c
+    ${BACNET_BASE}/src/bacnet/access_rule.c
+    ${BACNET_BASE}/src/bacnet/authentication_factor.c
     ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
+    ${BACNET_BASE}/src/bacnet/bacaction.c
+    ${BACNET_BASE}/src/bacnet/bacaddr.c
+    ${BACNET_BASE}/src/bacnet/bacapp.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacdest.c
+    ${BACNET_BASE}/src/bacnet/bacdevobjpropref.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/baclog.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/bactext.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
     ${BACNET_BASE}/src/bacnet/basic/sys/debug.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/keylist.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/lighting_command.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/linear.c
     ${BACNET_BASE}/src/bacnet/cov.c
-    )
-
-  get_filename_component(BACNET_OBJECT_SRC ${BACNET_SRC_PATH} PATH)
-  get_filename_component(BACNET_BASIC_SRC ${BACNET_OBJECT_SRC} PATH)
-  get_filename_component(BACNET_SRC ${BACNET_BASIC_SRC} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/access_rule.c
-    ${BACNET_SRC}/bacaction.c
-    ${BACNET_SRC}/bacaddr.c
-    ${BACNET_SRC}/bacapp.c
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacdest.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/baclog.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/channel_value.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/basic/sys/days.c
-    ${BACNET_SRC}/basic/sys/keylist.c
-    ${BACNET_SRC}/basic/sys/linear.c
-    ${BACNET_SRC}/bacdevobjpropref.c
-    ${BACNET_SRC}/bactext.c
-    ${BACNET_SRC}/indtext.c
-    ${BACNET_SRC}/lighting.c
-    ${BACNET_SRC}/proplist.c
-    ${BACNET_SRC}/wp.c
-    ${BACNET_SRC}/shed_level.c
-    ${BACNET_SRC}/timer_value.c
-    ${BACNET_SRC}/hostnport.c
-    ${BACNET_SRC}/dailyschedule.c
-    ${BACNET_SRC}/weeklyschedule.c
-    ${BACNET_SRC}/calendar_entry.c
-    ${BACNET_SRC}/special_event.c
-    ${BACNET_SRC}/basic/sys/bigend.c
-    ${BACNET_SRC}/bactimevalue.c
-    ${BACNET_SRC}/secure_connect.c
+    ${BACNET_BASE}/src/bacnet/datetime.c
+    ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_BASE}/src/bacnet/hostnport.c
+    ${BACNET_BASE}/src/bacnet/lighting.c
+    ${BACNET_BASE}/src/bacnet/proplist.c
+    ${BACNET_BASE}/src/bacnet/shed_level.c
+    ${BACNET_BASE}/src/bacnet/timer_value.c
+    ${BACNET_BASE}/src/bacnet/timestamp.c
+    ${BACNET_BASE}/src/bacnet/memcopy.c
+    ${BACNET_BASE}/src/bacnet/wp.c
+    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
+    ${BACNET_BASE}/src/bacnet/bactimevalue.c
+    ${BACNET_BASE}/src/bacnet/dailyschedule.c
+    ${BACNET_BASE}/src/bacnet/calendar_entry.c
+    ${BACNET_BASE}/src/bacnet/special_event.c
+    ${BACNET_BASE}/src/bacnet/channel_value.c
+    ${BACNET_BASE}/src/bacnet/secure_connect.c
+    ${BACNET_TEST_PATH}/src/main.c
+    ${BACNET_BASE}/test/bacnet/basic/object/test/device_mock.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/basic/object/command/CMakeLists.txt
+++ b/zephyr/tests/bacnet/basic/object/command/CMakeLists.txt
@@ -29,48 +29,41 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH TEST_OBJECT_INCLUDE $ENV{ZEPHYR_BASE} ${TEST_OBJECT_SRC})
   list(APPEND INCLUDE ${BACNET_INCLUDE} ${TEST_OBJECT_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${TEST_OBJECT_SRC}/property_test.c
+    ${BACNET_BASE}/src/bacnet/basic/object/command.c
+    ${BACNET_BASE}/src/bacnet/access_rule.c
     ${BACNET_BASE}/src/bacnet/authentication_factor.c
     ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
-    ${BACNET_BASE}/src/bacnet/basic/object/command.c
-    )
-
-  get_filename_component(BACNET_OBJECT_SRC ${BACNET_SRC_PATH} PATH)
-  get_filename_component(BACNET_BASIC_SRC ${BACNET_OBJECT_SRC} PATH)
-  get_filename_component(BACNET_SRC ${BACNET_BASIC_SRC} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/access_rule.c
-    ${BACNET_SRC}/bacaction.c
-    ${BACNET_SRC}/bacaddr.c
-    ${BACNET_SRC}/bacapp.c
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacdest.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/baclog.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/channel_value.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/basic/sys/days.c
-    ${BACNET_SRC}/bacdevobjpropref.c
-    ${BACNET_SRC}/bactext.c
-    ${BACNET_SRC}/indtext.c
-    ${BACNET_SRC}/lighting.c
-    ${BACNET_SRC}/proplist.c
-    ${BACNET_SRC}/wp.c
-    ${BACNET_SRC}/shed_level.c
-    ${BACNET_SRC}/timer_value.c
-    ${BACNET_SRC}/hostnport.c
-    ${BACNET_SRC}/dailyschedule.c
-    ${BACNET_SRC}/weeklyschedule.c
-    ${BACNET_SRC}/calendar_entry.c
-    ${BACNET_SRC}/special_event.c
-    ${BACNET_SRC}/basic/sys/bigend.c
-    ${BACNET_SRC}/bactimevalue.c
-    ${BACNET_SRC}/secure_connect.c
+    ${BACNET_BASE}/src/bacnet/bacaction.c
+    ${BACNET_BASE}/src/bacnet/bacaddr.c
+    ${BACNET_BASE}/src/bacnet/bacapp.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacdest.c
+    ${BACNET_BASE}/src/bacnet/bacdevobjpropref.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/baclog.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/bactext.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/datetime.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_BASE}/src/bacnet/hostnport.c
+    ${BACNET_BASE}/src/bacnet/lighting.c
+    ${BACNET_BASE}/src/bacnet/proplist.c
+    ${BACNET_BASE}/src/bacnet/shed_level.c
+    ${BACNET_BASE}/src/bacnet/timer_value.c
+    ${BACNET_BASE}/src/bacnet/timestamp.c
+    ${BACNET_BASE}/src/bacnet/wp.c
+    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
+    ${BACNET_BASE}/src/bacnet/bactimevalue.c
+    ${BACNET_BASE}/src/bacnet/dailyschedule.c
+    ${BACNET_BASE}/src/bacnet/calendar_entry.c
+    ${BACNET_BASE}/src/bacnet/special_event.c
+    ${BACNET_BASE}/src/bacnet/channel_value.c
+    ${BACNET_BASE}/src/bacnet/secure_connect.c
+    ${BACNET_TEST_PATH}/src/main.c
+    ${BACNET_BASE}/test/bacnet/basic/object/test/property_test.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/basic/object/credential_data_input/CMakeLists.txt
+++ b/zephyr/tests/bacnet/basic/object/credential_data_input/CMakeLists.txt
@@ -29,49 +29,42 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH TEST_OBJECT_INCLUDE $ENV{ZEPHYR_BASE} ${TEST_OBJECT_SRC})
   list(APPEND INCLUDE ${BACNET_INCLUDE} ${TEST_OBJECT_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${TEST_OBJECT_SRC}/property_test.c
-    ${BACNET_BASE}/src/bacnet/credential_authentication_factor.c
     ${BACNET_BASE}/src/bacnet/basic/object/credential_data_input.c
-    )
-
-  get_filename_component(BACNET_OBJECT_SRC ${BACNET_SRC_PATH} PATH)
-  get_filename_component(BACNET_BASIC_SRC ${BACNET_OBJECT_SRC} PATH)
-  get_filename_component(BACNET_SRC ${BACNET_BASIC_SRC} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/access_rule.c
-    ${BACNET_SRC}/bacaction.c
-    ${BACNET_SRC}/bacaddr.c
-    ${BACNET_SRC}/bacapp.c
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacdest.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/baclog.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/channel_value.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/basic/sys/days.c
-    ${BACNET_SRC}/bacdevobjpropref.c
-    ${BACNET_SRC}/bactext.c
-    ${BACNET_SRC}/indtext.c
-    ${BACNET_SRC}/lighting.c
-    ${BACNET_SRC}/proplist.c
-    ${BACNET_SRC}/wp.c
-    ${BACNET_SRC}/authentication_factor.c
-    ${BACNET_SRC}/authentication_factor_format.c
-    ${BACNET_SRC}/shed_level.c
-    ${BACNET_SRC}/timer_value.c
-    ${BACNET_SRC}/hostnport.c
-    ${BACNET_SRC}/dailyschedule.c
-    ${BACNET_SRC}/weeklyschedule.c
-    ${BACNET_SRC}/calendar_entry.c
-    ${BACNET_SRC}/special_event.c
-    ${BACNET_SRC}/basic/sys/bigend.c
-    ${BACNET_SRC}/bactimevalue.c
-    ${BACNET_SRC}/secure_connect.c
+    ${BACNET_BASE}/src/bacnet/access_rule.c
+    ${BACNET_BASE}/src/bacnet/authentication_factor.c
+    ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
+    ${BACNET_BASE}/src/bacnet/bacaction.c
+    ${BACNET_BASE}/src/bacnet/bacaddr.c
+    ${BACNET_BASE}/src/bacnet/bacapp.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacdest.c
+    ${BACNET_BASE}/src/bacnet/bacdevobjpropref.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/baclog.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/bactext.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/credential_authentication_factor.c
+    ${BACNET_BASE}/src/bacnet/datetime.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_BASE}/src/bacnet/hostnport.c
+    ${BACNET_BASE}/src/bacnet/lighting.c
+    ${BACNET_BASE}/src/bacnet/proplist.c
+    ${BACNET_BASE}/src/bacnet/shed_level.c
+    ${BACNET_BASE}/src/bacnet/timer_value.c
+    ${BACNET_BASE}/src/bacnet/timestamp.c
+    ${BACNET_BASE}/src/bacnet/wp.c
+    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
+    ${BACNET_BASE}/src/bacnet/bactimevalue.c
+    ${BACNET_BASE}/src/bacnet/dailyschedule.c
+    ${BACNET_BASE}/src/bacnet/calendar_entry.c
+    ${BACNET_BASE}/src/bacnet/special_event.c
+    ${BACNET_BASE}/src/bacnet/channel_value.c
+    ${BACNET_BASE}/src/bacnet/secure_connect.c
+    ${BACNET_TEST_PATH}/src/main.c
+    ${BACNET_BASE}/test/bacnet/basic/object/test/property_test.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/basic/object/lc/CMakeLists.txt
+++ b/zephyr/tests/bacnet/basic/object/lc/CMakeLists.txt
@@ -25,54 +25,50 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${BACNET_TEST_PATH}/stubs.c
-    ${BACNET_BASE}/src/bacnet/authentication_factor.c
-    ${BACNET_BASE}/src/bacnet/proplist.c
-    ${BACNET_BASE}/src/bacnet/bacerror.c
-    ${BACNET_BASE}/src/bacnet/basic/sys/keylist.c
-    ${BACNET_BASE}/src/bacnet/rp.c
     ${BACNET_BASE}/src/bacnet/basic/object/lc.c
+    ${BACNET_BASE}/src/bacnet/access_rule.c
+    ${BACNET_BASE}/src/bacnet/authentication_factor.c
     ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
+    ${BACNET_BASE}/src/bacnet/bacaction.c
+    ${BACNET_BASE}/src/bacnet/bacaddr.c
+    ${BACNET_BASE}/src/bacnet/bacapp.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacdest.c
+    ${BACNET_BASE}/src/bacnet/bacdevobjpropref.c
+    ${BACNET_BASE}/src/bacnet/abort.c
+    ${BACNET_BASE}/src/bacnet/bacerror.c
+    ${BACNET_BASE}/src/bacnet/reject.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/baclog.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/bactext.c
+    ${BACNET_BASE}/src/bacnet/basic/object/ao.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
     ${BACNET_BASE}/src/bacnet/basic/sys/debug.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/keylist.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
     ${BACNET_BASE}/src/bacnet/cov.c
-    )
-
-  get_filename_component(BACNET_OBJECT_SRC ${BACNET_SRC_PATH} PATH)
-  get_filename_component(BACNET_BASIC_SRC ${BACNET_OBJECT_SRC} PATH)
-  get_filename_component(BACNET_SRC ${BACNET_BASIC_SRC} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/access_rule.c
-    ${BACNET_SRC}/bacaction.c
-    ${BACNET_SRC}/bacaddr.c
-    ${BACNET_SRC}/bacapp.c
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacdest.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/baclog.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/channel_value.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/basic/sys/days.c
-    ${BACNET_SRC}/bacdevobjpropref.c
-    ${BACNET_SRC}/bactext.c
-    ${BACNET_SRC}/indtext.c
-    ${BACNET_SRC}/lighting.c
-    ${BACNET_SRC}/wp.c
-    ${BACNET_OBJECT_SRC}/ao.c
-    ${BACNET_SRC}/shed_level.c
-    ${BACNET_SRC}/timer_value.c
-    ${BACNET_SRC}/hostnport.c
-    ${BACNET_SRC}/dailyschedule.c
-    ${BACNET_SRC}/weeklyschedule.c
-    ${BACNET_SRC}/calendar_entry.c
-    ${BACNET_SRC}/special_event.c
-    ${BACNET_SRC}/basic/sys/bigend.c
-    ${BACNET_SRC}/bactimevalue.c
-    ${BACNET_SRC}/secure_connect.c
+    ${BACNET_BASE}/src/bacnet/datetime.c
+    ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_BASE}/src/bacnet/hostnport.c
+    ${BACNET_BASE}/src/bacnet/lighting.c
+    ${BACNET_BASE}/src/bacnet/proplist.c
+    ${BACNET_BASE}/src/bacnet/rp.c
+    ${BACNET_BASE}/src/bacnet/shed_level.c
+    ${BACNET_BASE}/src/bacnet/timer_value.c
+    ${BACNET_BASE}/src/bacnet/timestamp.c
+    ${BACNET_BASE}/src/bacnet/wp.c
+    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
+    ${BACNET_BASE}/src/bacnet/bactimevalue.c
+    ${BACNET_BASE}/src/bacnet/dailyschedule.c
+    ${BACNET_BASE}/src/bacnet/calendar_entry.c
+    ${BACNET_BASE}/src/bacnet/special_event.c
+    ${BACNET_BASE}/src/bacnet/channel_value.c
+    ${BACNET_BASE}/src/bacnet/secure_connect.c
+    ${BACNET_TEST_PATH}/src/main.c
+    ${BACNET_BASE}/test/bacnet/basic/object/test/datetime_local.c
+    ${BACNET_BASE}/test/bacnet/basic/object/test/property_test.c
     )
 
   add_definitions(-DUNIT_TESTING)

--- a/zephyr/tests/bacnet/basic/object/lo/CMakeLists.txt
+++ b/zephyr/tests/bacnet/basic/object/lo/CMakeLists.txt
@@ -29,56 +29,50 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH TEST_OBJECT_INCLUDE $ENV{ZEPHYR_BASE} ${TEST_OBJECT_SRC})
   list(APPEND INCLUDE ${BACNET_INCLUDE} ${TEST_OBJECT_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${TEST_OBJECT_SRC}/device_mock.c
-    ${TEST_OBJECT_SRC}/property_test.c
-    ${BACNET_BASE}/src/bacnet/basic/sys/color_rgb.c
-    ${BACNET_BASE}/src/bacnet/authentication_factor.c
     ${BACNET_BASE}/src/bacnet/basic/object/lo.c
-    ${BACNET_BASE}/src/bacnet/bacerror.c
+    ${BACNET_BASE}/src/bacnet/access_rule.c
+    ${BACNET_BASE}/src/bacnet/authentication_factor.c
     ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
-    )
-
-  get_filename_component(BACNET_OBJECT_SRC ${BACNET_SRC_PATH} PATH)
-  get_filename_component(BACNET_BASIC_SRC ${BACNET_OBJECT_SRC} PATH)
-  get_filename_component(BACNET_SRC ${BACNET_BASIC_SRC} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/access_rule.c
-    ${BACNET_SRC}/bacaction.c
-    ${BACNET_SRC}/bacaddr.c
-    ${BACNET_SRC}/bacapp.c
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacdest.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/baclog.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/channel_value.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/bacdevobjpropref.c
-    ${BACNET_SRC}/bactext.c
-    ${BACNET_SRC}/cov.c
-    ${BACNET_SRC}/indtext.c
-    ${BACNET_SRC}/lighting.c
-    ${BACNET_SRC}/proplist.c
-    ${BACNET_SRC}/wp.c
-    ${BACNET_SRC}/shed_level.c
-    ${BACNET_SRC}/timer_value.c
-    ${BACNET_SRC}/hostnport.c
-    ${BACNET_SRC}/dailyschedule.c
-    ${BACNET_SRC}/weeklyschedule.c
-    ${BACNET_SRC}/calendar_entry.c
-    ${BACNET_SRC}/special_event.c
-    ${BACNET_SRC}/bactimevalue.c
-    ${BACNET_SRC}/basic/sys/bigend.c
-    ${BACNET_SRC}/basic/sys/days.c
-    ${BACNET_SRC}/basic/sys/debug.c
-    ${BACNET_SRC}/basic/sys/keylist.c
-    ${BACNET_SRC}/basic/sys/lighting_command.c
-    ${BACNET_SRC}/basic/sys/linear.c
-    ${BACNET_SRC}/secure_connect.c
+    ${BACNET_BASE}/src/bacnet/bacaction.c
+    ${BACNET_BASE}/src/bacnet/bacaddr.c
+    ${BACNET_BASE}/src/bacnet/bacapp.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacdest.c
+    ${BACNET_BASE}/src/bacnet/bacdevobjpropref.c
+    ${BACNET_BASE}/src/bacnet/abort.c
+    ${BACNET_BASE}/src/bacnet/bacerror.c
+    ${BACNET_BASE}/src/bacnet/reject.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/baclog.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/bactext.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/color_rgb.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/debug.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/keylist.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/lighting_command.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/linear.c
+    ${BACNET_BASE}/src/bacnet/datetime.c
+    ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_BASE}/src/bacnet/hostnport.c
+    ${BACNET_BASE}/src/bacnet/lighting.c
+    ${BACNET_BASE}/src/bacnet/proplist.c
+    ${BACNET_BASE}/src/bacnet/shed_level.c
+    ${BACNET_BASE}/src/bacnet/timer_value.c
+    ${BACNET_BASE}/src/bacnet/timestamp.c
+    ${BACNET_BASE}/src/bacnet/wp.c
+    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
+    ${BACNET_BASE}/src/bacnet/bactimevalue.c
+    ${BACNET_BASE}/src/bacnet/dailyschedule.c
+    ${BACNET_BASE}/src/bacnet/calendar_entry.c
+    ${BACNET_BASE}/src/bacnet/special_event.c
+    ${BACNET_BASE}/src/bacnet/channel_value.c
+    ${BACNET_BASE}/src/bacnet/secure_connect.c
+    ${BACNET_TEST_PATH}/src/main.c
+    ${BACNET_BASE}/test/bacnet/basic/object/test/property_test.c
+    ${BACNET_BASE}/test/bacnet/basic/object/test/device_mock.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/basic/object/lsp/CMakeLists.txt
+++ b/zephyr/tests/bacnet/basic/object/lsp/CMakeLists.txt
@@ -25,49 +25,44 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
     ${BACNET_BASE}/src/bacnet/basic/object/lsp.c
+    ${BACNET_BASE}/src/bacnet/access_rule.c
     ${BACNET_BASE}/src/bacnet/authentication_factor.c
-    ${BACNET_BASE}/src/bacnet/bacerror.c
     ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
-    )
-
-  get_filename_component(BACNET_OBJECT_SRC ${BACNET_SRC_PATH} PATH)
-  get_filename_component(BACNET_BASIC_SRC ${BACNET_OBJECT_SRC} PATH)
-  get_filename_component(BACNET_SRC ${BACNET_BASIC_SRC} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/access_rule.c
-    ${BACNET_SRC}/bacaction.c
-    ${BACNET_SRC}/bacaddr.c
-    ${BACNET_SRC}/bacapp.c
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacdest.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/baclog.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/channel_value.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/basic/sys/days.c
-    ${BACNET_SRC}/basic/sys/keylist.c
-    ${BACNET_SRC}/bacdevobjpropref.c
-    ${BACNET_SRC}/bactext.c
-    ${BACNET_SRC}/indtext.c
-    ${BACNET_SRC}/lighting.c
-    ${BACNET_SRC}/proplist.c
-    ${BACNET_SRC}/wp.c
-    ${BACNET_SRC}/shed_level.c
-    ${BACNET_SRC}/timer_value.c
-    ${BACNET_SRC}/hostnport.c
-    ${BACNET_SRC}/dailyschedule.c
-    ${BACNET_SRC}/weeklyschedule.c
-    ${BACNET_SRC}/calendar_entry.c
-    ${BACNET_SRC}/special_event.c
-    ${BACNET_SRC}/basic/sys/bigend.c
-    ${BACNET_SRC}/bactimevalue.c
-    ${BACNET_SRC}/secure_connect.c
+    ${BACNET_BASE}/src/bacnet/bacaction.c
+    ${BACNET_BASE}/src/bacnet/bacaddr.c
+    ${BACNET_BASE}/src/bacnet/bacapp.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacdest.c
+    ${BACNET_BASE}/src/bacnet/bacdevobjpropref.c
+    ${BACNET_BASE}/src/bacnet/abort.c
+    ${BACNET_BASE}/src/bacnet/bacerror.c
+    ${BACNET_BASE}/src/bacnet/reject.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/baclog.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/bactext.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/keylist.c
+    ${BACNET_BASE}/src/bacnet/datetime.c
+    ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_BASE}/src/bacnet/hostnport.c
+    ${BACNET_BASE}/src/bacnet/lighting.c
+    ${BACNET_BASE}/src/bacnet/proplist.c
+    ${BACNET_BASE}/src/bacnet/shed_level.c
+    ${BACNET_BASE}/src/bacnet/timer_value.c
+    ${BACNET_BASE}/src/bacnet/timestamp.c
+    ${BACNET_BASE}/src/bacnet/wp.c
+    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
+    ${BACNET_BASE}/src/bacnet/bactimevalue.c
+    ${BACNET_BASE}/src/bacnet/dailyschedule.c
+    ${BACNET_BASE}/src/bacnet/calendar_entry.c
+    ${BACNET_BASE}/src/bacnet/special_event.c
+    ${BACNET_BASE}/src/bacnet/channel_value.c
+    ${BACNET_BASE}/src/bacnet/secure_connect.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/basic/object/ms-input/CMakeLists.txt
+++ b/zephyr/tests/bacnet/basic/object/ms-input/CMakeLists.txt
@@ -29,52 +29,45 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH TEST_OBJECT_INCLUDE $ENV{ZEPHYR_BASE} ${TEST_OBJECT_SRC})
   list(APPEND INCLUDE ${BACNET_INCLUDE} ${TEST_OBJECT_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${TEST_OBJECT_SRC}/property_test.c
     ${BACNET_BASE}/src/bacnet/basic/object/ms-input.c
+    ${BACNET_BASE}/src/bacnet/access_rule.c
     ${BACNET_BASE}/src/bacnet/authentication_factor.c
     ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
+    ${BACNET_BASE}/src/bacnet/bacaction.c
+    ${BACNET_BASE}/src/bacnet/bacaddr.c
+    ${BACNET_BASE}/src/bacnet/bacapp.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacdest.c
+    ${BACNET_BASE}/src/bacnet/bacdevobjpropref.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/baclog.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/bactext.c
+    ${BACNET_BASE}/src/bacnet/cov.c
+    ${BACNET_BASE}/src/bacnet/datetime.c
+    ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_BASE}/src/bacnet/hostnport.c
+    ${BACNET_BASE}/src/bacnet/lighting.c
+    ${BACNET_BASE}/src/bacnet/proplist.c
+    ${BACNET_BASE}/src/bacnet/shed_level.c
+    ${BACNET_BASE}/src/bacnet/timer_value.c
+    ${BACNET_BASE}/src/bacnet/timestamp.c
+    ${BACNET_BASE}/src/bacnet/wp.c
+    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
+    ${BACNET_BASE}/src/bacnet/bactimevalue.c
+    ${BACNET_BASE}/src/bacnet/dailyschedule.c
+    ${BACNET_BASE}/src/bacnet/calendar_entry.c
+    ${BACNET_BASE}/src/bacnet/special_event.c
+    ${BACNET_BASE}/src/bacnet/secure_connect.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/debug.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/keylist.c
+    ${BACNET_BASE}/src/bacnet/channel_value.c
+    ${BACNET_TEST_PATH}/src/main.c
+    ${BACNET_BASE}/test/bacnet/basic/object/test/property_test.c
     )
-
-  get_filename_component(BACNET_OBJECT_SRC ${BACNET_SRC_PATH} PATH)
-  get_filename_component(BACNET_BASIC_SRC ${BACNET_OBJECT_SRC} PATH)
-  get_filename_component(BACNET_SRC ${BACNET_BASIC_SRC} PATH)
-  list(APPEND SOURCES
-  ${BACNET_SRC}/access_rule.c
-  ${BACNET_SRC}/bacaction.c
-  ${BACNET_SRC}/bacaddr.c
-  ${BACNET_SRC}/bacapp.c
-  ${BACNET_SRC}/bacdcode.c
-  ${BACNET_SRC}/bacdest.c
-  ${BACNET_SRC}/bacint.c
-  ${BACNET_SRC}/baclog.c
-  ${BACNET_SRC}/bacreal.c
-  ${BACNET_SRC}/bacstr.c
-  ${BACNET_SRC}/channel_value.c
-  ${BACNET_SRC}/datetime.c
-  ${BACNET_SRC}/bacdevobjpropref.c
-  ${BACNET_SRC}/bactext.c
-  ${BACNET_SRC}/cov.c
-  ${BACNET_SRC}/indtext.c
-  ${BACNET_SRC}/lighting.c
-  ${BACNET_SRC}/proplist.c
-  ${BACNET_SRC}/timestamp.c
-  ${BACNET_SRC}/wp.c
-  ${BACNET_SRC}/shed_level.c
-  ${BACNET_SRC}/timer_value.c
-  ${BACNET_SRC}/hostnport.c
-  ${BACNET_SRC}/dailyschedule.c
-  ${BACNET_SRC}/weeklyschedule.c
-  ${BACNET_SRC}/calendar_entry.c
-  ${BACNET_SRC}/special_event.c
-  ${BACNET_SRC}/bactimevalue.c
-  ${BACNET_SRC}/basic/sys/bigend.c
-  ${BACNET_SRC}/basic/sys/days.c
-  ${BACNET_SRC}/basic/sys/debug.c
-  ${BACNET_SRC}/basic/sys/keylist.c
-  ${BACNET_SRC}/secure_connect.c
-  )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")
   find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/zephyr/tests/bacnet/basic/object/mso/CMakeLists.txt
+++ b/zephyr/tests/bacnet/basic/object/mso/CMakeLists.txt
@@ -29,53 +29,46 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH TEST_OBJECT_INCLUDE $ENV{ZEPHYR_BASE} ${TEST_OBJECT_SRC})
   list(APPEND INCLUDE ${BACNET_INCLUDE} ${TEST_OBJECT_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${TEST_OBJECT_SRC}/property_test.c
-    ${BACNET_BASE}/src/bacnet/authentication_factor.c
-    ${BACNET_BASE}/src/bacnet/memcopy.c
-    ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
     ${BACNET_BASE}/src/bacnet/basic/object/mso.c
-  )
-
-  get_filename_component(BACNET_OBJECT_SRC ${BACNET_SRC_PATH} PATH)
-  get_filename_component(BACNET_BASIC_SRC ${BACNET_OBJECT_SRC} PATH)
-  get_filename_component(BACNET_SRC ${BACNET_BASIC_SRC} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/access_rule.c
-    ${BACNET_SRC}/bacaction.c
-    ${BACNET_SRC}/bacaddr.c
-    ${BACNET_SRC}/bacapp.c
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacdest.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/baclog.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/channel_value.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/bacdevobjpropref.c
-    ${BACNET_SRC}/bactext.c
-    ${BACNET_SRC}/cov.c
-    ${BACNET_SRC}/indtext.c
-    ${BACNET_SRC}/lighting.c
-    ${BACNET_SRC}/proplist.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/wp.c
-    ${BACNET_SRC}/shed_level.c
-    ${BACNET_SRC}/timer_value.c
-    ${BACNET_SRC}/hostnport.c
-    ${BACNET_SRC}/dailyschedule.c
-    ${BACNET_SRC}/weeklyschedule.c
-    ${BACNET_SRC}/calendar_entry.c
-    ${BACNET_SRC}/special_event.c
-    ${BACNET_SRC}/bactimevalue.c
-    ${BACNET_SRC}/basic/sys/bigend.c
-    ${BACNET_SRC}/basic/sys/days.c
-    ${BACNET_SRC}/basic/sys/debug.c
-    ${BACNET_SRC}/basic/sys/keylist.c
-    ${BACNET_SRC}/secure_connect.c
-  )
+    ${BACNET_BASE}/src/bacnet/access_rule.c
+    ${BACNET_BASE}/src/bacnet/authentication_factor.c
+    ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
+    ${BACNET_BASE}/src/bacnet/bacaction.c
+    ${BACNET_BASE}/src/bacnet/bacaddr.c
+    ${BACNET_BASE}/src/bacnet/bacapp.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacdest.c
+    ${BACNET_BASE}/src/bacnet/bacdevobjpropref.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/baclog.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/bactext.c
+    ${BACNET_BASE}/src/bacnet/cov.c
+    ${BACNET_BASE}/src/bacnet/datetime.c
+    ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_BASE}/src/bacnet/hostnport.c
+    ${BACNET_BASE}/src/bacnet/lighting.c
+    ${BACNET_BASE}/src/bacnet/proplist.c
+    ${BACNET_BASE}/src/bacnet/memcopy.c
+    ${BACNET_BASE}/src/bacnet/shed_level.c
+    ${BACNET_BASE}/src/bacnet/timer_value.c
+    ${BACNET_BASE}/src/bacnet/timestamp.c
+    ${BACNET_BASE}/src/bacnet/wp.c
+    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
+    ${BACNET_BASE}/src/bacnet/bactimevalue.c
+    ${BACNET_BASE}/src/bacnet/dailyschedule.c
+    ${BACNET_BASE}/src/bacnet/calendar_entry.c
+    ${BACNET_BASE}/src/bacnet/special_event.c
+    ${BACNET_BASE}/src/bacnet/channel_value.c
+    ${BACNET_BASE}/src/bacnet/secure_connect.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/debug.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/keylist.c
+    ${BACNET_TEST_PATH}/src/main.c
+    ${BACNET_BASE}/test/bacnet/basic/object/test/property_test.c
+    )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")
   find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/zephyr/tests/bacnet/basic/object/msv/CMakeLists.txt
+++ b/zephyr/tests/bacnet/basic/object/msv/CMakeLists.txt
@@ -29,52 +29,45 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH TEST_OBJECT_INCLUDE $ENV{ZEPHYR_BASE} ${TEST_OBJECT_SRC})
   list(APPEND INCLUDE ${BACNET_INCLUDE} ${TEST_OBJECT_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${TEST_OBJECT_SRC}/property_test.c
-    ${BACNET_BASE}/src/bacnet/authentication_factor.c
     ${BACNET_BASE}/src/bacnet/basic/object/msv.c
+    ${BACNET_BASE}/src/bacnet/access_rule.c
+    ${BACNET_BASE}/src/bacnet/authentication_factor.c
     ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
+    ${BACNET_BASE}/src/bacnet/bacaction.c
+    ${BACNET_BASE}/src/bacnet/bacaddr.c
+    ${BACNET_BASE}/src/bacnet/bacapp.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacdest.c
+    ${BACNET_BASE}/src/bacnet/bacdevobjpropref.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/baclog.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/bactext.c
+    ${BACNET_BASE}/src/bacnet/cov.c
+    ${BACNET_BASE}/src/bacnet/datetime.c
+    ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_BASE}/src/bacnet/hostnport.c
+    ${BACNET_BASE}/src/bacnet/lighting.c
+    ${BACNET_BASE}/src/bacnet/proplist.c
+    ${BACNET_BASE}/src/bacnet/shed_level.c
+    ${BACNET_BASE}/src/bacnet/timer_value.c
+    ${BACNET_BASE}/src/bacnet/timestamp.c
+    ${BACNET_BASE}/src/bacnet/wp.c
+    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
+    ${BACNET_BASE}/src/bacnet/bactimevalue.c
+    ${BACNET_BASE}/src/bacnet/dailyschedule.c
+    ${BACNET_BASE}/src/bacnet/calendar_entry.c
+    ${BACNET_BASE}/src/bacnet/special_event.c
+    ${BACNET_BASE}/src/bacnet/channel_value.c
+    ${BACNET_BASE}/src/bacnet/secure_connect.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/debug.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/keylist.c
+    ${BACNET_TEST_PATH}/src/main.c
+    ${BACNET_BASE}/test/bacnet/basic/object/test/property_test.c
     )
-
-  get_filename_component(BACNET_OBJECT_SRC ${BACNET_SRC_PATH} PATH)
-  get_filename_component(BACNET_BASIC_SRC ${BACNET_OBJECT_SRC} PATH)
-  get_filename_component(BACNET_SRC ${BACNET_BASIC_SRC} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/access_rule.c
-    ${BACNET_SRC}/bacaction.c
-    ${BACNET_SRC}/bacaddr.c
-    ${BACNET_SRC}/bacapp.c
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacdest.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/baclog.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/channel_value.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/bacdevobjpropref.c
-    ${BACNET_SRC}/bactext.c
-    ${BACNET_SRC}/cov.c
-    ${BACNET_SRC}/indtext.c
-    ${BACNET_SRC}/lighting.c
-    ${BACNET_SRC}/proplist.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/wp.c
-    ${BACNET_SRC}/shed_level.c
-    ${BACNET_SRC}/timer_value.c
-    ${BACNET_SRC}/hostnport.c
-    ${BACNET_SRC}/dailyschedule.c
-    ${BACNET_SRC}/weeklyschedule.c
-    ${BACNET_SRC}/calendar_entry.c
-    ${BACNET_SRC}/special_event.c
-    ${BACNET_SRC}/bactimevalue.c
-    ${BACNET_SRC}/basic/sys/bigend.c
-    ${BACNET_SRC}/basic/sys/days.c
-    ${BACNET_SRC}/basic/sys/debug.c
-    ${BACNET_SRC}/basic/sys/keylist.c
-    ${BACNET_SRC}/secure_connect.c
-  )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")
   find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/zephyr/tests/bacnet/basic/object/netport/CMakeLists.txt
+++ b/zephyr/tests/bacnet/basic/object/netport/CMakeLists.txt
@@ -29,60 +29,56 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH TEST_OBJECT_INCLUDE $ENV{ZEPHYR_BASE} ${TEST_OBJECT_SRC})
   list(APPEND INCLUDE ${BACNET_INCLUDE} ${TEST_OBJECT_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${TEST_OBJECT_SRC}/property_test.c
-    ${BACNET_BASE}/src/bacnet/arf.c
-    ${BACNET_BASE}/src/bacnet/basic/sys/filename.c
     ${BACNET_BASE}/src/bacnet/basic/object/bacfile.c
-    ${BACNET_BASE}/src/bacnet/property.c
-    ${BACNET_BASE}/src/bacnet/authentication_factor.c
-    ${BACNET_BASE}/src/bacnet/basic/object/sc_netport.c
     ${BACNET_BASE}/src/bacnet/basic/object/netport.c
+    ${BACNET_BASE}/src/bacnet/basic/object/sc_netport.c
+    ${BACNET_BASE}/src/bacnet/access_rule.c
+    ${BACNET_BASE}/src/bacnet/authentication_factor.c
+    ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
+    ${BACNET_BASE}/src/bacnet/arf.c
+    ${BACNET_BASE}/src/bacnet/bacaction.c
+    ${BACNET_BASE}/src/bacnet/bacaddr.c
+    ${BACNET_BASE}/src/bacnet/bacapp.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacdest.c
+    ${BACNET_BASE}/src/bacnet/bacdevobjpropref.c
+    ${BACNET_BASE}/src/bacnet/abort.c
+    ${BACNET_BASE}/src/bacnet/bacerror.c
+    ${BACNET_BASE}/src/bacnet/reject.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/baclog.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/bactext.c
+    ${BACNET_BASE}/src/bacnet/datetime.c
+    ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_BASE}/src/bacnet/hostnport.c
+    ${BACNET_BASE}/src/bacnet/lighting.c
+    ${BACNET_BASE}/src/bacnet/proplist.c
+    ${BACNET_BASE}/src/bacnet/property.c
+    ${BACNET_BASE}/src/bacnet/shed_level.c
+    ${BACNET_BASE}/src/bacnet/timer_value.c
+    ${BACNET_BASE}/src/bacnet/timestamp.c
+    ${BACNET_BASE}/src/bacnet/wp.c
+    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
+    ${BACNET_BASE}/src/bacnet/bactimevalue.c
+    ${BACNET_BASE}/src/bacnet/dailyschedule.c
+    ${BACNET_BASE}/src/bacnet/calendar_entry.c
+    ${BACNET_BASE}/src/bacnet/special_event.c
+    ${BACNET_BASE}/src/bacnet/channel_value.c
+    ${BACNET_BASE}/src/bacnet/secure_connect.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/debug.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/filename.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/keylist.c
+    ${BACNET_BASE}/src/bacnet/datalink/bvlc.c
     ${BACNET_BASE}/src/bacnet/datalink/bvlc6.c
     ${BACNET_BASE}/src/bacnet/datalink/bsc/bsc-util.c
-    ${BACNET_BASE}/src/bacnet/bacerror.c
-    ${BACNET_BASE}/src/bacnet/basic/sys/keylist.c
-    ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
-    ${BACNET_BASE}/src/bacnet/basic/sys/debug.c
-    )
-
-  get_filename_component(BACNET_OBJECT_SRC ${BACNET_SRC_PATH} PATH)
-  get_filename_component(BACNET_BASIC_SRC ${BACNET_OBJECT_SRC} PATH)
-  get_filename_component(BACNET_SRC ${BACNET_BASIC_SRC} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/access_rule.c
-    ${BACNET_SRC}/bacaction.c
-    ${BACNET_SRC}/bacaddr.c
-    ${BACNET_SRC}/bacapp.c
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacdest.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/baclog.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/channel_value.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/basic/sys/days.c
-    ${BACNET_SRC}/bacdevobjpropref.c
-    ${BACNET_SRC}/bactext.c
-    ${BACNET_SRC}/indtext.c
-    ${BACNET_SRC}/lighting.c
-    ${BACNET_SRC}/proplist.c
-    ${BACNET_SRC}/wp.c
-    ${BACNET_SRC}/proplist.c
-    ${BACNET_SRC}/datalink/bvlc.c
-    ${BACNET_SRC}/shed_level.c
-    ${BACNET_SRC}/timer_value.c
-    ${BACNET_SRC}/hostnport.c
-    ${BACNET_SRC}/dailyschedule.c
-    ${BACNET_SRC}/weeklyschedule.c
-    ${BACNET_SRC}/calendar_entry.c
-    ${BACNET_SRC}/special_event.c
-    ${BACNET_SRC}/basic/sys/bigend.c
-    ${BACNET_SRC}/bactimevalue.c
-    ${BACNET_SRC}/secure_connect.c
+    ${BACNET_BASE}/test/bacnet/basic/object/test/device_mock.c
+    ${BACNET_BASE}/test/bacnet/basic/object/test/datetime_local.c
+    ${BACNET_BASE}/test/bacnet/basic/object/test/property_test.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/basic/object/objects/CMakeLists.txt
+++ b/zephyr/tests/bacnet/basic/object/objects/CMakeLists.txt
@@ -25,48 +25,9 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
     ${BACNET_BASE}/src/bacnet/basic/object/objects.c
-    )
-
-  get_filename_component(BACNET_OBJECT_SRC ${BACNET_SRC_PATH} PATH)
-  get_filename_component(BACNET_BASIC_SRC ${BACNET_OBJECT_SRC} PATH)
-  get_filename_component(BACNET_SRC ${BACNET_BASIC_SRC} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/access_rule.c
-    ${BACNET_SRC}/bacaction.c
-    ${BACNET_SRC}/bacaddr.c
-    ${BACNET_SRC}/bacapp.c
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacdest.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/baclog.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/channel_value.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/basic/sys/days.c
-    ${BACNET_SRC}/bacdevobjpropref.c
-    ${BACNET_SRC}/bactext.c
-    ${BACNET_SRC}/indtext.c
-    ${BACNET_SRC}/lighting.c
-    ${BACNET_SRC}/proplist.c
-    ${BACNET_SRC}/wp.c
-    ${BACNET_BASIC_SRC}/sys/keylist.c
-    ${BACNET_SRC}/shed_level.c
-    ${BACNET_SRC}/timer_value.c
-    ${BACNET_SRC}/hostnport.c
-    ${BACNET_SRC}/dailyschedule.c
-    ${BACNET_SRC}/weeklyschedule.c
-    ${BACNET_SRC}/calendar_entry.c
-    ${BACNET_SRC}/special_event.c
-    ${BACNET_SRC}/basic/sys/bigend.c
-    ${BACNET_SRC}/bactimevalue.c
-    ${BACNET_SRC}/secure_connect.c
-    ${BACNET_SRC}/authentication_factor.c
-    ${BACNET_SRC}/authentication_factor_format.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/keylist.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/basic/object/osv/CMakeLists.txt
+++ b/zephyr/tests/bacnet/basic/object/osv/CMakeLists.txt
@@ -29,52 +29,43 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH TEST_OBJECT_INCLUDE $ENV{ZEPHYR_BASE} ${TEST_OBJECT_SRC})
   list(APPEND INCLUDE ${BACNET_INCLUDE} ${TEST_OBJECT_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${TEST_OBJECT_SRC}/property_test.c
+    ${BACNET_BASE}/src/bacnet/basic/object/osv.c
+    ${BACNET_BASE}/src/bacnet/access_rule.c
     ${BACNET_BASE}/src/bacnet/authentication_factor.c
     ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
-    ${BACNET_BASE}/src/bacnet/basic/object/osv.c
+    ${BACNET_BASE}/src/bacnet/bacaction.c
+    ${BACNET_BASE}/src/bacnet/bacaddr.c
+    ${BACNET_BASE}/src/bacnet/bacapp.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacdest.c
+    ${BACNET_BASE}/src/bacnet/bacdevobjpropref.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/baclog.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/bactext.c
+    ${BACNET_BASE}/src/bacnet/datetime.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/keylist.c
+    ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_BASE}/src/bacnet/hostnport.c
+    ${BACNET_BASE}/src/bacnet/lighting.c
+    ${BACNET_BASE}/src/bacnet/proplist.c
+    ${BACNET_BASE}/src/bacnet/shed_level.c
+    ${BACNET_BASE}/src/bacnet/timer_value.c
+    ${BACNET_BASE}/src/bacnet/timestamp.c
+    ${BACNET_BASE}/src/bacnet/wp.c
+    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
+    ${BACNET_BASE}/src/bacnet/bactimevalue.c
+    ${BACNET_BASE}/src/bacnet/dailyschedule.c
+    ${BACNET_BASE}/src/bacnet/calendar_entry.c
+    ${BACNET_BASE}/src/bacnet/special_event.c
+    ${BACNET_BASE}/src/bacnet/channel_value.c
+    ${BACNET_BASE}/src/bacnet/secure_connect.c
+    ${BACNET_TEST_PATH}/src/main.c
+    ${BACNET_BASE}/test/bacnet/basic/object/test/property_test.c
     )
-
-  get_filename_component(BACNET_OBJECT_SRC ${BACNET_SRC_PATH} PATH)
-  get_filename_component(BACNET_BASIC_SRC ${BACNET_OBJECT_SRC} PATH)
-  get_filename_component(BACNET_SRC ${BACNET_BASIC_SRC} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/access_rule.c
-    ${BACNET_SRC}/bacaction.c
-    ${BACNET_SRC}/bacaddr.c
-    ${BACNET_SRC}/bacapp.c
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacdest.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/baclog.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/channel_value.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/bacdevobjpropref.c
-    ${BACNET_SRC}/bactext.c
-    ${BACNET_SRC}/cov.c
-    ${BACNET_SRC}/indtext.c
-    ${BACNET_SRC}/lighting.c
-    ${BACNET_SRC}/proplist.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/wp.c
-    ${BACNET_SRC}/shed_level.c
-    ${BACNET_SRC}/timer_value.c
-    ${BACNET_SRC}/hostnport.c
-    ${BACNET_SRC}/dailyschedule.c
-    ${BACNET_SRC}/weeklyschedule.c
-    ${BACNET_SRC}/calendar_entry.c
-    ${BACNET_SRC}/special_event.c
-    ${BACNET_SRC}/bactimevalue.c
-    ${BACNET_SRC}/basic/sys/bigend.c
-    ${BACNET_SRC}/basic/sys/days.c
-    ${BACNET_SRC}/basic/sys/debug.c
-    ${BACNET_SRC}/basic/sys/keylist.c
-    ${BACNET_SRC}/secure_connect.c
-  )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")
   find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/zephyr/tests/bacnet/basic/object/piv/CMakeLists.txt
+++ b/zephyr/tests/bacnet/basic/object/piv/CMakeLists.txt
@@ -29,50 +29,42 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH TEST_OBJECT_INCLUDE $ENV{ZEPHYR_BASE} ${TEST_OBJECT_SRC})
   list(APPEND INCLUDE ${BACNET_INCLUDE} ${TEST_OBJECT_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${TEST_OBJECT_SRC}/property_test.c
     ${BACNET_BASE}/src/bacnet/basic/object/piv.c
+    ${BACNET_BASE}/src/bacnet/access_rule.c
     ${BACNET_BASE}/src/bacnet/authentication_factor.c
     ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
-    )
-
-  get_filename_component(BACNET_OBJECT_SRC ${BACNET_SRC_PATH} PATH)
-  get_filename_component(BACNET_BASIC_SRC ${BACNET_OBJECT_SRC} PATH)
-  get_filename_component(BACNET_SRC ${BACNET_BASIC_SRC} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/access_rule.c
-    ${BACNET_SRC}/bacaction.c
-    ${BACNET_SRC}/bacaddr.c
-    ${BACNET_SRC}/bacapp.c
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacdest.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/baclog.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/channel_value.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/basic/sys/days.c
-    ${BACNET_SRC}/basic/sys/keylist.c
-    ${BACNET_SRC}/bacdevobjpropref.c
-    ${BACNET_SRC}/bactext.c
-    ${BACNET_SRC}/indtext.c
-    ${BACNET_SRC}/lighting.c
-    ${BACNET_SRC}/proplist.c
-    ${BACNET_SRC}/wp.c
-    ${BACNET_SRC}/proplist.c
-    ${BACNET_SRC}/shed_level.c
-    ${BACNET_SRC}/timer_value.c
-    ${BACNET_SRC}/hostnport.c
-    ${BACNET_SRC}/dailyschedule.c
-    ${BACNET_SRC}/weeklyschedule.c
-    ${BACNET_SRC}/calendar_entry.c
-    ${BACNET_SRC}/special_event.c
-    ${BACNET_SRC}/basic/sys/bigend.c
-    ${BACNET_SRC}/bactimevalue.c
-    ${BACNET_SRC}/secure_connect.c
+    ${BACNET_BASE}/src/bacnet/bacaction.c
+    ${BACNET_BASE}/src/bacnet/bacaddr.c
+    ${BACNET_BASE}/src/bacnet/bacapp.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacdest.c
+    ${BACNET_BASE}/src/bacnet/bacdevobjpropref.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/baclog.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/bactext.c
+    ${BACNET_BASE}/src/bacnet/datetime.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/keylist.c
+    ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_BASE}/src/bacnet/hostnport.c
+    ${BACNET_BASE}/src/bacnet/lighting.c
+    ${BACNET_BASE}/src/bacnet/proplist.c
+    ${BACNET_BASE}/src/bacnet/shed_level.c
+    ${BACNET_BASE}/src/bacnet/timer_value.c
+    ${BACNET_BASE}/src/bacnet/timestamp.c
+    ${BACNET_BASE}/src/bacnet/wp.c
+    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
+    ${BACNET_BASE}/src/bacnet/bactimevalue.c
+    ${BACNET_BASE}/src/bacnet/dailyschedule.c
+    ${BACNET_BASE}/src/bacnet/calendar_entry.c
+    ${BACNET_BASE}/src/bacnet/special_event.c
+    ${BACNET_BASE}/src/bacnet/channel_value.c
+    ${BACNET_BASE}/src/bacnet/secure_connect.c
+    ${BACNET_TEST_PATH}/src/main.c
+    ${BACNET_BASE}/test/bacnet/basic/object/test/property_test.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/basic/object/schedule/CMakeLists.txt
+++ b/zephyr/tests/bacnet/basic/object/schedule/CMakeLists.txt
@@ -29,51 +29,43 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH TEST_OBJECT_INCLUDE $ENV{ZEPHYR_BASE} ${TEST_OBJECT_SRC})
   list(APPEND INCLUDE ${BACNET_INCLUDE} ${TEST_OBJECT_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${TEST_OBJECT_SRC}/property_test.c
-    ${TEST_OBJECT_SRC}/device_mock.c
-    ${BACNET_BASE}/src/bacnet/authentication_factor.c
     ${BACNET_BASE}/src/bacnet/basic/object/schedule.c
+    ${BACNET_BASE}/src/bacnet/access_rule.c
+    ${BACNET_BASE}/src/bacnet/authentication_factor.c
     ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
-    )
-
-  get_filename_component(BACNET_OBJECT_SRC ${BACNET_SRC_PATH} PATH)
-  get_filename_component(BACNET_BASIC_SRC ${BACNET_OBJECT_SRC} PATH)
-  get_filename_component(BACNET_SRC ${BACNET_BASIC_SRC} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/access_rule.c
-    ${BACNET_SRC}/bacaction.c
-    ${BACNET_SRC}/bacaddr.c
-    ${BACNET_SRC}/bacapp.c
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacdest.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/baclog.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/channel_value.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/basic/sys/days.c
-    ${BACNET_SRC}/basic/sys/debug.c
-    ${BACNET_SRC}/bacdevobjpropref.c
-    ${BACNET_SRC}/bactext.c
-    ${BACNET_SRC}/indtext.c
-    ${BACNET_SRC}/lighting.c
-    ${BACNET_SRC}/proplist.c
-    ${BACNET_SRC}/wp.c
-    ${BACNET_SRC}/bactimevalue.c
-    ${BACNET_SRC}/shed_level.c
-    ${BACNET_SRC}/timer_value.c
-    ${BACNET_SRC}/hostnport.c
-    ${BACNET_SRC}/dailyschedule.c
-    ${BACNET_SRC}/weeklyschedule.c
-    ${BACNET_SRC}/calendar_entry.c
-    ${BACNET_SRC}/special_event.c
-    ${BACNET_SRC}/basic/sys/bigend.c
-    ${BACNET_SRC}/bactimevalue.c
-    ${BACNET_SRC}/secure_connect.c
+    ${BACNET_BASE}/src/bacnet/bacaction.c
+    ${BACNET_BASE}/src/bacnet/bacaddr.c
+    ${BACNET_BASE}/src/bacnet/bacapp.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacdest.c
+    ${BACNET_BASE}/src/bacnet/bacdevobjpropref.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/baclog.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/bactext.c
+    ${BACNET_BASE}/src/bacnet/bactimevalue.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/datetime.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/debug.c
+    ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_BASE}/src/bacnet/hostnport.c
+    ${BACNET_BASE}/src/bacnet/lighting.c
+    ${BACNET_BASE}/src/bacnet/proplist.c
+    ${BACNET_BASE}/src/bacnet/shed_level.c
+    ${BACNET_BASE}/src/bacnet/timer_value.c
+    ${BACNET_BASE}/src/bacnet/timestamp.c
+    ${BACNET_BASE}/src/bacnet/wp.c
+    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
+    ${BACNET_BASE}/src/bacnet/dailyschedule.c
+    ${BACNET_BASE}/src/bacnet/calendar_entry.c
+    ${BACNET_BASE}/src/bacnet/special_event.c
+    ${BACNET_BASE}/src/bacnet/channel_value.c
+    ${BACNET_BASE}/src/bacnet/secure_connect.c
+    ${BACNET_TEST_PATH}/src/main.c
+    ${BACNET_BASE}/test/bacnet/basic/object/test/property_test.c
+    ${BACNET_BASE}/test/bacnet/basic/object/test/device_mock.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/basic/object/time_value/CMakeLists.txt
+++ b/zephyr/tests/bacnet/basic/object/time_value/CMakeLists.txt
@@ -29,54 +29,46 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH TEST_OBJECT_INCLUDE $ENV{ZEPHYR_BASE} ${TEST_OBJECT_SRC})
   list(APPEND INCLUDE ${BACNET_INCLUDE} ${TEST_OBJECT_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${TEST_OBJECT_SRC}/datetime_local.c
-    ${TEST_OBJECT_SRC}/property_test.c
-    ${TEST_OBJECT_SRC}/device_mock.c
-    ${BACNET_BASE}/src/bacnet/authentication_factor.c
     ${BACNET_BASE}/src/bacnet/basic/object/time_value.c
-    ${BACNET_BASE}/src/bacnet/memcopy.c
+    ${BACNET_BASE}/src/bacnet/access_rule.c
+    ${BACNET_BASE}/src/bacnet/authentication_factor.c
     ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
+    ${BACNET_BASE}/src/bacnet/bacaction.c
+    ${BACNET_BASE}/src/bacnet/bacaddr.c
+    ${BACNET_BASE}/src/bacnet/bacapp.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacdest.c
+    ${BACNET_BASE}/src/bacnet/bacdevobjpropref.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/baclog.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/bactext.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
     ${BACNET_BASE}/src/bacnet/cov.c
-    )
-
-  get_filename_component(BACNET_OBJECT_SRC ${BACNET_SRC_PATH} PATH)
-  get_filename_component(BACNET_BASIC_SRC ${BACNET_OBJECT_SRC} PATH)
-  get_filename_component(BACNET_SRC ${BACNET_BASIC_SRC} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/access_rule.c
-    ${BACNET_SRC}/bacaction.c
-    ${BACNET_SRC}/bacaddr.c
-    ${BACNET_SRC}/bacapp.c
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacdest.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/baclog.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/channel_value.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/basic/sys/days.c
-    ${BACNET_SRC}/basic/sys/keylist.c
-    ${BACNET_SRC}/bacdevobjpropref.c
-    ${BACNET_SRC}/bactext.c
-    ${BACNET_SRC}/indtext.c
-    ${BACNET_SRC}/lighting.c
-    ${BACNET_SRC}/proplist.c
-    ${BACNET_SRC}/wp.c
-    ${BACNET_SRC}/bactimevalue.c
-    ${BACNET_SRC}/shed_level.c
-    ${BACNET_SRC}/timer_value.c
-    ${BACNET_SRC}/hostnport.c
-    ${BACNET_SRC}/dailyschedule.c
-    ${BACNET_SRC}/weeklyschedule.c
-    ${BACNET_SRC}/calendar_entry.c
-    ${BACNET_SRC}/special_event.c
-    ${BACNET_SRC}/basic/sys/bigend.c
-    ${BACNET_SRC}/bactimevalue.c
-    ${BACNET_SRC}/secure_connect.c
+    ${BACNET_BASE}/src/bacnet/datetime.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/keylist.c
+    ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_BASE}/src/bacnet/hostnport.c
+    ${BACNET_BASE}/src/bacnet/lighting.c
+    ${BACNET_BASE}/src/bacnet/proplist.c
+    ${BACNET_BASE}/src/bacnet/shed_level.c
+    ${BACNET_BASE}/src/bacnet/timer_value.c
+    ${BACNET_BASE}/src/bacnet/timestamp.c
+    ${BACNET_BASE}/src/bacnet/memcopy.c
+    ${BACNET_BASE}/src/bacnet/wp.c
+    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
+    ${BACNET_BASE}/src/bacnet/bactimevalue.c
+    ${BACNET_BASE}/src/bacnet/dailyschedule.c
+    ${BACNET_BASE}/src/bacnet/calendar_entry.c
+    ${BACNET_BASE}/src/bacnet/special_event.c
+    ${BACNET_BASE}/src/bacnet/channel_value.c
+    ${BACNET_BASE}/src/bacnet/secure_connect.c
+    ${BACNET_TEST_PATH}/src/main.c
+    ${BACNET_BASE}/test/bacnet/basic/object/test/datetime_local.c
+    ${BACNET_BASE}/test/bacnet/basic/object/test/device_mock.c
+    ${BACNET_BASE}/test/bacnet/basic/object/test/property_test.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/basic/sys/fifo/CMakeLists.txt
+++ b/zephyr/tests/bacnet/basic/sys/fifo/CMakeLists.txt
@@ -18,14 +18,12 @@ string(REGEX REPLACE
   ${CMAKE_CURRENT_SOURCE_DIR})
 get_filename_component(BACNET_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
-
 if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
     ${BACNET_BASE}/src/bacnet/basic/sys/fifo.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/basic/sys/filename/CMakeLists.txt
+++ b/zephyr/tests/bacnet/basic/sys/filename/CMakeLists.txt
@@ -25,16 +25,9 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
     ${BACNET_BASE}/src/bacnet/basic/sys/filename.c
-    )
-  get_filename_component(BACNET_SYS_SRC ${BACNET_SRC_PATH} PATH)
-  get_filename_component(BACNET_BASIC_SRC ${BACNET_SYS_SRC} PATH)
-  get_filename_component(BACNET_SRC ${BACNET_BASIC_SRC} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/basic/sys/keylist.c
-    ${BACNET_SRC}/basic/sys/debug.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/debug.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/basic/sys/keylist/CMakeLists.txt
+++ b/zephyr/tests/bacnet/basic/sys/keylist/CMakeLists.txt
@@ -18,14 +18,12 @@ string(REGEX REPLACE
   ${CMAKE_CURRENT_SOURCE_DIR})
 get_filename_component(BACNET_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
-
 if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
     ${BACNET_BASE}/src/bacnet/basic/sys/keylist.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/basic/sys/ringbuf/CMakeLists.txt
+++ b/zephyr/tests/bacnet/basic/sys/ringbuf/CMakeLists.txt
@@ -18,14 +18,12 @@ string(REGEX REPLACE
   ${CMAKE_CURRENT_SOURCE_DIR})
 get_filename_component(BACNET_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
-
 if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
     ${BACNET_BASE}/src/bacnet/basic/sys/ringbuf.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/basic/sys/sbuf/CMakeLists.txt
+++ b/zephyr/tests/bacnet/basic/sys/sbuf/CMakeLists.txt
@@ -18,14 +18,12 @@ string(REGEX REPLACE
   ${CMAKE_CURRENT_SOURCE_DIR})
 get_filename_component(BACNET_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
-
 if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
     ${BACNET_BASE}/src/bacnet/basic/sys/sbuf.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/cov/CMakeLists.txt
+++ b/zephyr/tests/bacnet/cov/CMakeLists.txt
@@ -25,44 +25,39 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
+    ${BACNET_BASE}/src/bacnet/cov.c
+    ${BACNET_BASE}/src/bacnet/access_rule.c
     ${BACNET_BASE}/src/bacnet/authentication_factor.c
     ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
-    ${BACNET_BASE}/src/bacnet/cov.c
-    )
-
-  get_filename_component(BACNET_SRC ${BACNET_SRC_PATH} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/access_rule.c
-    ${BACNET_SRC}/bacaction.c
-    ${BACNET_SRC}/bacaddr.c
-    ${BACNET_SRC}/bacapp.c
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacdest.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/baclog.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/channel_value.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/basic/sys/days.c
-    ${BACNET_SRC}/bacdevobjpropref.c
-    ${BACNET_SRC}/bactext.c
-    ${BACNET_SRC}/indtext.c
-    ${BACNET_SRC}/lighting.c
-    ${BACNET_SRC}/memcopy.c
-    ${BACNET_SRC}/shed_level.c
-    ${BACNET_SRC}/timer_value.c
-    ${BACNET_SRC}/hostnport.c
-    ${BACNET_SRC}/dailyschedule.c
-    ${BACNET_SRC}/weeklyschedule.c
-    ${BACNET_SRC}/calendar_entry.c
-    ${BACNET_SRC}/special_event.c
-    ${BACNET_SRC}/basic/sys/bigend.c
-    ${BACNET_SRC}/bactimevalue.c
-    ${BACNET_SRC}/secure_connect.c
+    ${BACNET_BASE}/src/bacnet/bacaction.c
+    ${BACNET_BASE}/src/bacnet/bacaddr.c
+    ${BACNET_BASE}/src/bacnet/bacapp.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacdest.c
+    ${BACNET_BASE}/src/bacnet/bacdevobjpropref.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/baclog.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/bactext.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/datetime.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_BASE}/src/bacnet/hostnport.c
+    ${BACNET_BASE}/src/bacnet/lighting.c
+    ${BACNET_BASE}/src/bacnet/shed_level.c
+    ${BACNET_BASE}/src/bacnet/timer_value.c
+    ${BACNET_BASE}/src/bacnet/timestamp.c
+    ${BACNET_BASE}/src/bacnet/memcopy.c
+    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
+    ${BACNET_BASE}/src/bacnet/bactimevalue.c
+    ${BACNET_BASE}/src/bacnet/dailyschedule.c
+    ${BACNET_BASE}/src/bacnet/calendar_entry.c
+    ${BACNET_BASE}/src/bacnet/special_event.c
+    ${BACNET_BASE}/src/bacnet/channel_value.c
+    ${BACNET_BASE}/src/bacnet/secure_connect.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   add_definitions(-DBACAPP_PRINT_ENABLED=1 -DBACAPP_SNPRINTF_ENABLED=1)

--- a/zephyr/tests/bacnet/datalink/bvlc/CMakeLists.txt
+++ b/zephyr/tests/bacnet/datalink/bvlc/CMakeLists.txt
@@ -25,26 +25,17 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
     ${BACNET_BASE}/src/bacnet/datalink/bvlc.c
-    )
-
-  get_filename_component(BACNET_DATALINK_SRC ${BACNET_SRC_PATH} PATH)
-  get_filename_component(BACNET_SRC ${BACNET_DATALINK_SRC} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/basic/sys/days.c
-    ${BACNET_SRC}/bacdevobjpropref.c
-    ${BACNET_SRC}/hostnport.c
-    ${BACNET_SRC}/bactext.c
-    ${BACNET_SRC}/indtext.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/bactext.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/hostnport.c
+    ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   # BIP Options

--- a/zephyr/tests/bacnet/datalink/cobs/CMakeLists.txt
+++ b/zephyr/tests/bacnet/datalink/cobs/CMakeLists.txt
@@ -25,9 +25,8 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
+    ${BACNET_BASE}/src/bacnet/datalink/cobs.c
     ${BACNET_TEST_PATH}/src/main.c
-    ${BACNET_DATALINK_SRC}/cobs.c
     )
 
   add_definitions(-DBACDL_MSTP=1)

--- a/zephyr/tests/bacnet/datalink/crc/CMakeLists.txt
+++ b/zephyr/tests/bacnet/datalink/crc/CMakeLists.txt
@@ -18,14 +18,12 @@ string(REGEX REPLACE
   ${CMAKE_CURRENT_SOURCE_DIR})
 get_filename_component(BACNET_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
-
 if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
     ${BACNET_BASE}/src/bacnet/datalink/crc.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   add_definitions(-DBACDL_MSTP=1)

--- a/zephyr/tests/bacnet/datalink/mock/CMakeLists.txt
+++ b/zephyr/tests/bacnet/datalink/mock/CMakeLists.txt
@@ -29,15 +29,13 @@ if(BOARD STREQUAL unit_testing)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
 
   file(GLOB SRC_TEST ${BACNET_TEST_PATH}/src/*.c)
-  list(APPEND SOURCES ${SRC_TEST} )
-
   list(APPEND SOURCES
-    ${BACNET_DATALINK_SRC}/datalink.c
-    ${BACNET_BASE}/src/bacnet/bacint.c
-    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
-    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/datalink/datalink.c
     ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
     ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
     ${BACNET_BASE}/src/bacnet/basic/sys/days.c
     )
 

--- a/zephyr/tests/bacnet/datetime/CMakeLists.txt
+++ b/zephyr/tests/bacnet/datetime/CMakeLists.txt
@@ -25,20 +25,14 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
     ${BACNET_BASE}/src/bacnet/datetime.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
     ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
-    )
-
-  get_filename_component(BACNET_SRC ${BACNET_SRC_PATH} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/dcc/CMakeLists.txt
+++ b/zephyr/tests/bacnet/dcc/CMakeLists.txt
@@ -25,21 +25,13 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
     ${BACNET_BASE}/src/bacnet/dcc.c
-    )
-
-  get_filename_component(BACNET_SRC ${BACNET_SRC_PATH} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/event/CMakeLists.txt
+++ b/zephyr/tests/bacnet/event/CMakeLists.txt
@@ -25,46 +25,40 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
-    ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
     ${BACNET_BASE}/src/bacnet/event.c
+    ${BACNET_BASE}/src/bacnet/authentication_factor.c
+    ${BACNET_BASE}/src/bacnet/bacaddr.c
+    ${BACNET_BASE}/src/bacnet/bacapp.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacdest.c
+    ${BACNET_BASE}/src/bacnet/bacdevobjpropref.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/baclog.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/bacpropstates.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/datetime.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/access_rule.c
+    ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
+    ${BACNET_BASE}/src/bacnet/bacaction.c
+    ${BACNET_BASE}/src/bacnet/bactext.c
+    ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
+    ${BACNET_BASE}/src/bacnet/bactimevalue.c
+    ${BACNET_BASE}/src/bacnet/dailyschedule.c
+    ${BACNET_BASE}/src/bacnet/lighting.c
+    ${BACNET_BASE}/src/bacnet/shed_level.c
+    ${BACNET_BASE}/src/bacnet/timer_value.c
+    ${BACNET_BASE}/src/bacnet/timestamp.c
+    ${BACNET_BASE}/src/bacnet/hostnport.c
+    ${BACNET_BASE}/src/bacnet/calendar_entry.c
+    ${BACNET_BASE}/src/bacnet/special_event.c
+    ${BACNET_BASE}/src/bacnet/channel_value.c
+    ${BACNET_BASE}/src/bacnet/secure_connect.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
-
-  get_filename_component(BACNET_SRC ${BACNET_SRC_PATH} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/access_rule.c
-    ${BACNET_SRC}/bacaddr.c
-    ${BACNET_SRC}/bacapp.c
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacdest.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/baclog.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/channel_value.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/basic/sys/days.c
-    ${BACNET_SRC}/bacdevobjpropref.c
-    ${BACNET_SRC}/authentication_factor.c
-    ${BACNET_SRC}/bacpropstates.c
-    # Dependencies of bacapp.c
-    ${BACNET_SRC}/bacaction.c
-    ${BACNET_SRC}/bactext.c
-    ${BACNET_SRC}/indtext.c
-    ${BACNET_SRC}/weeklyschedule.c
-    ${BACNET_SRC}/calendar_entry.c
-    ${BACNET_SRC}/special_event.c
-    ${BACNET_SRC}/bactimevalue.c
-    ${BACNET_SRC}/dailyschedule.c
-    ${BACNET_SRC}/lighting.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/shed_level.c
-    ${BACNET_SRC}/timer_value.c
-    ${BACNET_SRC}/hostnport.c
-    ${BACNET_SRC}/secure_connect.c
-  )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")
   find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/zephyr/tests/bacnet/getevent/CMakeLists.txt
+++ b/zephyr/tests/bacnet/getevent/CMakeLists.txt
@@ -25,44 +25,39 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${BACNET_BASE}/src/bacnet/baclog.c
+    ${BACNET_BASE}/src/bacnet/getevent.c
     ${BACNET_BASE}/src/bacnet/access_rule.c
-    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
-    ${BACNET_BASE}/src/bacnet/shed_level.c
-    ${BACNET_BASE}/src/bacnet/dailyschedule.c
-    ${BACNET_BASE}/src/bacnet/bacdest.c
     ${BACNET_BASE}/src/bacnet/authentication_factor.c
-    ${BACNET_BASE}/src/bacnet/bacpropstates.c
-    ${BACNET_BASE}/src/bacnet/timer_value.c
+    ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
+    ${BACNET_BASE}/src/bacnet/bacaction.c
     ${BACNET_BASE}/src/bacnet/bacaddr.c
     ${BACNET_BASE}/src/bacnet/bacapp.c
-    ${BACNET_BASE}/src/bacnet/lighting.c
-    ${BACNET_BASE}/src/bacnet/bactimevalue.c
-    ${BACNET_BASE}/src/bacnet/hostnport.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacdest.c
+    ${BACNET_BASE}/src/bacnet/bacdevobjpropref.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/baclog.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/bactext.c
+    ${BACNET_BASE}/src/bacnet/bacpropstates.c
     ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/datetime.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/hostnport.c
+    ${BACNET_BASE}/src/bacnet/lighting.c
+    ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_BASE}/src/bacnet/shed_level.c
+    ${BACNET_BASE}/src/bacnet/timer_value.c
+    ${BACNET_BASE}/src/bacnet/timestamp.c
+    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
+    ${BACNET_BASE}/src/bacnet/bactimevalue.c
+    ${BACNET_BASE}/src/bacnet/dailyschedule.c
+    ${BACNET_BASE}/src/bacnet/calendar_entry.c
     ${BACNET_BASE}/src/bacnet/special_event.c
     ${BACNET_BASE}/src/bacnet/channel_value.c
-    ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
-    ${BACNET_BASE}/src/bacnet/indtext.c
     ${BACNET_BASE}/src/bacnet/secure_connect.c
-    ${BACNET_BASE}/src/bacnet/getevent.c
-    ${BACNET_BASE}/src/bacnet/bactext.c
-    ${BACNET_BASE}/src/bacnet/calendar_entry.c
-    ${BACNET_BASE}/src/bacnet/bacdevobjpropref.c
-    ${BACNET_BASE}/src/bacnet/bacaction.c
-    )
-
-  get_filename_component(BACNET_SRC ${BACNET_SRC_PATH} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/basic/sys/days.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/iam/CMakeLists.txt
+++ b/zephyr/tests/bacnet/iam/CMakeLists.txt
@@ -25,21 +25,13 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
     ${BACNET_BASE}/src/bacnet/iam.c
-    )
-
-  get_filename_component(BACNET_SRC ${BACNET_SRC_PATH} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/ihave/CMakeLists.txt
+++ b/zephyr/tests/bacnet/ihave/CMakeLists.txt
@@ -25,21 +25,13 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
     ${BACNET_BASE}/src/bacnet/ihave.c
-    )
-
-  get_filename_component(BACNET_SRC ${BACNET_SRC_PATH} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/indtext/CMakeLists.txt
+++ b/zephyr/tests/bacnet/indtext/CMakeLists.txt
@@ -18,19 +18,14 @@ string(REGEX REPLACE
   ${CMAKE_CURRENT_SOURCE_DIR})
 get_filename_component(BACNET_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
-
 if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
     ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
-  get_filename_component(BACNET_SRC ${BACNET_SRC_PATH} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/bacstr.c
-  )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")
   find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/zephyr/tests/bacnet/lighting/CMakeLists.txt
+++ b/zephyr/tests/bacnet/lighting/CMakeLists.txt
@@ -25,23 +25,15 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
     ${BACNET_BASE}/src/bacnet/lighting.c
-    )
-
-  get_filename_component(BACNET_SRC ${BACNET_SRC_PATH} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/bactext.c
-    ${BACNET_SRC}/indtext.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/bactext.c
+    ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/lso/CMakeLists.txt
+++ b/zephyr/tests/bacnet/lso/CMakeLists.txt
@@ -25,45 +25,42 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${BACNET_BASE}/src/bacnet/baclog.c
-    ${BACNET_BASE}/src/bacnet/access_rule.c
-    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
-    ${BACNET_BASE}/src/bacnet/shed_level.c
-    ${BACNET_BASE}/src/bacnet/dailyschedule.c
-    ${BACNET_BASE}/src/bacnet/bacdest.c
-    ${BACNET_BASE}/src/bacnet/authentication_factor.c
-    ${BACNET_BASE}/src/bacnet/timer_value.c
-    ${BACNET_BASE}/src/bacnet/bacaddr.c
-    ${BACNET_BASE}/src/bacnet/bacerror.c
-    ${BACNET_BASE}/src/bacnet/bacapp.c
-    ${BACNET_BASE}/src/bacnet/lighting.c
-    ${BACNET_BASE}/src/bacnet/bactimevalue.c
-    ${BACNET_BASE}/src/bacnet/hostnport.c
-    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
-    ${BACNET_BASE}/src/bacnet/special_event.c
-    ${BACNET_BASE}/src/bacnet/memcopy.c
     ${BACNET_BASE}/src/bacnet/lso.c
-    ${BACNET_BASE}/src/bacnet/channel_value.c
+    ${BACNET_BASE}/src/bacnet/access_rule.c
+    ${BACNET_BASE}/src/bacnet/authentication_factor.c
     ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
-    ${BACNET_BASE}/src/bacnet/indtext.c
-    ${BACNET_BASE}/src/bacnet/secure_connect.c
-    ${BACNET_BASE}/src/bacnet/bactext.c
-    ${BACNET_BASE}/src/bacnet/calendar_entry.c
-    ${BACNET_BASE}/src/bacnet/bacdevobjpropref.c
     ${BACNET_BASE}/src/bacnet/bacaction.c
-    )
-
-  get_filename_component(BACNET_SRC ${BACNET_SRC_PATH} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/bacaddr.c
+    ${BACNET_BASE}/src/bacnet/bacapp.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacdest.c
+    ${BACNET_BASE}/src/bacnet/bacdevobjpropref.c
+    ${BACNET_BASE}/src/bacnet/abort.c
+    ${BACNET_BASE}/src/bacnet/bacerror.c
+    ${BACNET_BASE}/src/bacnet/reject.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/baclog.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/bactext.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/datetime.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_BASE}/src/bacnet/hostnport.c
+    ${BACNET_BASE}/src/bacnet/lighting.c
+    ${BACNET_BASE}/src/bacnet/shed_level.c
+    ${BACNET_BASE}/src/bacnet/timer_value.c
+    ${BACNET_BASE}/src/bacnet/timestamp.c
+    ${BACNET_BASE}/src/bacnet/memcopy.c
+    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
+    ${BACNET_BASE}/src/bacnet/bactimevalue.c
+    ${BACNET_BASE}/src/bacnet/dailyschedule.c
+    ${BACNET_BASE}/src/bacnet/calendar_entry.c
+    ${BACNET_BASE}/src/bacnet/special_event.c
+    ${BACNET_BASE}/src/bacnet/channel_value.c
+    ${BACNET_BASE}/src/bacnet/secure_connect.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/memcopy/CMakeLists.txt
+++ b/zephyr/tests/bacnet/memcopy/CMakeLists.txt
@@ -18,14 +18,12 @@ string(REGEX REPLACE
   ${CMAKE_CURRENT_SOURCE_DIR})
 get_filename_component(BACNET_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
-
 if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
     ${BACNET_BASE}/src/bacnet/memcopy.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/npdu/CMakeLists.txt
+++ b/zephyr/tests/bacnet/npdu/CMakeLists.txt
@@ -25,33 +25,28 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
     ${BACNET_BASE}/src/bacnet/npdu.c
-    )
-
-  get_filename_component(BACNET_SRC ${BACNET_SRC_PATH} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/abort.c
-    ${BACNET_SRC}/bacaction.c
-    ${BACNET_SRC}/bacaddr.c
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacerror.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/bactext.c
-    ${BACNET_SRC}/basic/service/h_apdu.c
-    ${BACNET_SRC}/basic/sys/bigend.c
-    ${BACNET_SRC}/basic/sys/debug.c
-    ${BACNET_SRC}/basic/tsm/tsm.c
-    ${BACNET_SRC}/dcc.c
-    ${BACNET_SRC}/indtext.c
-    ${BACNET_SRC}/proplist.c
-    ${BACNET_SRC}/reject.c
-    ${BACNET_SRC}/rp.c
-    ${BACNET_SRC}/whois.c
+    ${BACNET_BASE}/src/bacnet/abort.c
+    ${BACNET_BASE}/src/bacnet/bacaction.c
+    ${BACNET_BASE}/src/bacnet/bacaddr.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacerror.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/bactext.c
+    ${BACNET_BASE}/src/bacnet/basic/service/h_apdu.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/debug.c
+    ${BACNET_BASE}/src/bacnet/basic/tsm/tsm.c
+    ${BACNET_BASE}/src/bacnet/dcc.c
+    ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_BASE}/src/bacnet/proplist.c
+    ${BACNET_BASE}/src/bacnet/reject.c
+    ${BACNET_BASE}/src/bacnet/rp.c
+    ${BACNET_BASE}/src/bacnet/whois.c
     ${BACNET_TEST_PATH}/stubs.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/property/CMakeLists.txt
+++ b/zephyr/tests/bacnet/property/CMakeLists.txt
@@ -25,24 +25,16 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
     ${BACNET_BASE}/src/bacnet/property.c
-    )
-
-  get_filename_component(BACNET_SRC ${BACNET_SRC_PATH} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/proplist.c
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/bactext.c
-    ${BACNET_SRC}/indtext.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/proplist.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/bactext.c
+    ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   add_definitions(

--- a/zephyr/tests/bacnet/ptransfer/CMakeLists.txt
+++ b/zephyr/tests/bacnet/ptransfer/CMakeLists.txt
@@ -25,43 +25,38 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
     ${BACNET_BASE}/src/bacnet/ptransfer.c
+    ${BACNET_BASE}/src/bacnet/access_rule.c
     ${BACNET_BASE}/src/bacnet/authentication_factor.c
     ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
-    )
-
-  get_filename_component(BACNET_SRC ${BACNET_SRC_PATH} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/access_rule.c
-    ${BACNET_SRC}/bacaction.c
-    ${BACNET_SRC}/bacaddr.c
-    ${BACNET_SRC}/bacapp.c
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacdest.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/baclog.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/channel_value.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/basic/sys/days.c
-    ${BACNET_SRC}/bacdevobjpropref.c
-    ${BACNET_SRC}/bactext.c
-    ${BACNET_SRC}/indtext.c
-    ${BACNET_SRC}/lighting.c
-    ${BACNET_SRC}/shed_level.c
-    ${BACNET_SRC}/timer_value.c
-    ${BACNET_SRC}/hostnport.c
-    ${BACNET_SRC}/dailyschedule.c
-    ${BACNET_SRC}/weeklyschedule.c
-    ${BACNET_SRC}/calendar_entry.c
-    ${BACNET_SRC}/special_event.c
-    ${BACNET_SRC}/basic/sys/bigend.c
-    ${BACNET_SRC}/bactimevalue.c
-    ${BACNET_SRC}/secure_connect.c
+    ${BACNET_BASE}/src/bacnet/bacaction.c
+    ${BACNET_BASE}/src/bacnet/bacaddr.c
+    ${BACNET_BASE}/src/bacnet/bacapp.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacdest.c
+    ${BACNET_BASE}/src/bacnet/bacdevobjpropref.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/baclog.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/bactext.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/datetime.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_BASE}/src/bacnet/hostnport.c
+    ${BACNET_BASE}/src/bacnet/lighting.c
+    ${BACNET_BASE}/src/bacnet/shed_level.c
+    ${BACNET_BASE}/src/bacnet/timer_value.c
+    ${BACNET_BASE}/src/bacnet/timestamp.c
+    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
+    ${BACNET_BASE}/src/bacnet/bactimevalue.c
+    ${BACNET_BASE}/src/bacnet/dailyschedule.c
+    ${BACNET_BASE}/src/bacnet/calendar_entry.c
+    ${BACNET_BASE}/src/bacnet/special_event.c
+    ${BACNET_BASE}/src/bacnet/channel_value.c
+    ${BACNET_BASE}/src/bacnet/secure_connect.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   add_definitions(-DBACAPP_PRINT_ENABLED=1 -DBACAPP_SNPRINTF_ENABLED=1)

--- a/zephyr/tests/bacnet/rd/CMakeLists.txt
+++ b/zephyr/tests/bacnet/rd/CMakeLists.txt
@@ -25,18 +25,13 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
     ${BACNET_BASE}/src/bacnet/rd.c
-    )
-
-  get_filename_component(BACNET_SRC ${BACNET_SRC_PATH} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/reject/CMakeLists.txt
+++ b/zephyr/tests/bacnet/reject/CMakeLists.txt
@@ -18,19 +18,17 @@ string(REGEX REPLACE
   ${CMAKE_CURRENT_SOURCE_DIR})
 get_filename_component(BACNET_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
-
 if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${BACNET_BASE}/src/bacnet/bacint.c
     ${BACNET_BASE}/src/bacnet/reject.c
-    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
-    ${BACNET_BASE}/src/bacnet/bacstr.c
     ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
     ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/rp/CMakeLists.txt
+++ b/zephyr/tests/bacnet/rp/CMakeLists.txt
@@ -25,19 +25,14 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
     ${BACNET_BASE}/src/bacnet/rp.c
-    )
-
-  get_filename_component(BACNET_SRC ${BACNET_SRC_PATH} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/proplist.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/proplist.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/rpm/CMakeLists.txt
+++ b/zephyr/tests/bacnet/rpm/CMakeLists.txt
@@ -25,45 +25,42 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${BACNET_BASE}/src/bacnet/authentication_factor.c
     ${BACNET_BASE}/src/bacnet/rpm.c
+    ${BACNET_BASE}/src/bacnet/access_rule.c
+    ${BACNET_BASE}/src/bacnet/authentication_factor.c
     ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
-    )
-
-  get_filename_component(BACNET_SRC ${BACNET_SRC_PATH} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/access_rule.c
-    ${BACNET_SRC}/bacaction.c
-    ${BACNET_SRC}/bacaddr.c
-    ${BACNET_SRC}/bacapp.c
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacdest.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/baclog.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/channel_value.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/basic/sys/days.c
-    ${BACNET_SRC}/bacdevobjpropref.c
-    ${BACNET_SRC}/bactext.c
-    ${BACNET_SRC}/indtext.c
-    ${BACNET_SRC}/lighting.c
-    ${BACNET_SRC}/bacerror.c
-    ${BACNET_SRC}/memcopy.c
-    ${BACNET_SRC}/shed_level.c
-    ${BACNET_SRC}/timer_value.c
-    ${BACNET_SRC}/hostnport.c
-    ${BACNET_SRC}/dailyschedule.c
-    ${BACNET_SRC}/weeklyschedule.c
-    ${BACNET_SRC}/calendar_entry.c
-    ${BACNET_SRC}/special_event.c
-    ${BACNET_SRC}/basic/sys/bigend.c
-    ${BACNET_SRC}/bactimevalue.c
-    ${BACNET_SRC}/secure_connect.c
+    ${BACNET_BASE}/src/bacnet/bacaction.c
+    ${BACNET_BASE}/src/bacnet/bacaddr.c
+    ${BACNET_BASE}/src/bacnet/bacapp.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacdest.c
+    ${BACNET_BASE}/src/bacnet/bacdevobjpropref.c
+    ${BACNET_BASE}/src/bacnet/abort.c
+    ${BACNET_BASE}/src/bacnet/bacerror.c
+    ${BACNET_BASE}/src/bacnet/reject.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/baclog.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/bactext.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/datetime.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_BASE}/src/bacnet/hostnport.c
+    ${BACNET_BASE}/src/bacnet/lighting.c
+    ${BACNET_BASE}/src/bacnet/shed_level.c
+    ${BACNET_BASE}/src/bacnet/timer_value.c
+    ${BACNET_BASE}/src/bacnet/timestamp.c
+    ${BACNET_BASE}/src/bacnet/memcopy.c
+    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
+    ${BACNET_BASE}/src/bacnet/bactimevalue.c
+    ${BACNET_BASE}/src/bacnet/dailyschedule.c
+    ${BACNET_BASE}/src/bacnet/calendar_entry.c
+    ${BACNET_BASE}/src/bacnet/special_event.c
+    ${BACNET_BASE}/src/bacnet/channel_value.c
+    ${BACNET_BASE}/src/bacnet/secure_connect.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/timestamp/CMakeLists.txt
+++ b/zephyr/tests/bacnet/timestamp/CMakeLists.txt
@@ -25,20 +25,15 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
     ${BACNET_BASE}/src/bacnet/timestamp.c
-    )
-
-  get_filename_component(BACNET_SRC ${BACNET_SRC_PATH} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/datetime.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/timesync/CMakeLists.txt
+++ b/zephyr/tests/bacnet/timesync/CMakeLists.txt
@@ -25,44 +25,41 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${BACNET_BASE}/src/bacnet/baclog.c
-    ${BACNET_BASE}/src/bacnet/access_rule.c
-    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
-    ${BACNET_BASE}/src/bacnet/shed_level.c
-    ${BACNET_BASE}/src/bacnet/dailyschedule.c
-    ${BACNET_BASE}/src/bacnet/authentication_factor.c
-    ${BACNET_BASE}/src/bacnet/timer_value.c
-    ${BACNET_BASE}/src/bacnet/bacerror.c
-    ${BACNET_BASE}/src/bacnet/bacapp.c
-    ${BACNET_BASE}/src/bacnet/lighting.c
-    ${BACNET_BASE}/src/bacnet/bactimevalue.c
-    ${BACNET_BASE}/src/bacnet/hostnport.c
     ${BACNET_BASE}/src/bacnet/timesync.c
+    ${BACNET_BASE}/src/bacnet/access_rule.c
+    ${BACNET_BASE}/src/bacnet/authentication_factor.c
+    ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
+    ${BACNET_BASE}/src/bacnet/bacaction.c
+    ${BACNET_BASE}/src/bacnet/bacaddr.c
+    ${BACNET_BASE}/src/bacnet/bacapp.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacdest.c
+    ${BACNET_BASE}/src/bacnet/bacdevobjpropref.c
+    ${BACNET_BASE}/src/bacnet/abort.c
+    ${BACNET_BASE}/src/bacnet/bacerror.c
+    ${BACNET_BASE}/src/bacnet/reject.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/baclog.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/bactext.c
     ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/datetime.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_BASE}/src/bacnet/hostnport.c
+    ${BACNET_BASE}/src/bacnet/lighting.c
+    ${BACNET_BASE}/src/bacnet/shed_level.c
+    ${BACNET_BASE}/src/bacnet/timer_value.c
+    ${BACNET_BASE}/src/bacnet/timestamp.c
+    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
+    ${BACNET_BASE}/src/bacnet/bactimevalue.c
+    ${BACNET_BASE}/src/bacnet/dailyschedule.c
+    ${BACNET_BASE}/src/bacnet/calendar_entry.c
     ${BACNET_BASE}/src/bacnet/special_event.c
     ${BACNET_BASE}/src/bacnet/channel_value.c
-    ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
     ${BACNET_BASE}/src/bacnet/secure_connect.c
-    ${BACNET_BASE}/src/bacnet/calendar_entry.c
-    ${BACNET_BASE}/src/bacnet/bacdevobjpropref.c
-    ${BACNET_BASE}/src/bacnet/bacaction.c
-    )
-
-  get_filename_component(BACNET_SRC ${BACNET_SRC_PATH} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/bacaddr.c
-    ${BACNET_SRC}/bacdest.c
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/bactext.c
-    ${BACNET_SRC}/indtext.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/basic/sys/days.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/whohas/CMakeLists.txt
+++ b/zephyr/tests/bacnet/whohas/CMakeLists.txt
@@ -25,18 +25,13 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
     ${BACNET_BASE}/src/bacnet/whohas.c
-    )
-
-  get_filename_component(BACNET_SRC ${BACNET_SRC_PATH} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/whois/CMakeLists.txt
+++ b/zephyr/tests/bacnet/whois/CMakeLists.txt
@@ -25,18 +25,13 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
-    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
     ${BACNET_BASE}/src/bacnet/whois.c
-    )
-
-  get_filename_component(BACNET_SRC ${BACNET_SRC_PATH} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")

--- a/zephyr/tests/bacnet/wp/CMakeLists.txt
+++ b/zephyr/tests/bacnet/wp/CMakeLists.txt
@@ -25,44 +25,39 @@ if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
   list(APPEND INCLUDE ${BACNET_INCLUDE})
   list(APPEND SOURCES
-    ${BACNET_SRC_PATH}.c
-    ${BACNET_TEST_PATH}/src/main.c
     ${BACNET_BASE}/src/bacnet/wp.c
+    ${BACNET_BASE}/src/bacnet/access_rule.c
     ${BACNET_BASE}/src/bacnet/authentication_factor.c
     ${BACNET_BASE}/src/bacnet/authentication_factor_format.c
-    )
-
-  get_filename_component(BACNET_SRC ${BACNET_SRC_PATH} PATH)
-  list(APPEND SOURCES
-    ${BACNET_SRC}/access_rule.c
-    ${BACNET_SRC}/bacaction.c
-    ${BACNET_SRC}/bacaddr.c
-    ${BACNET_SRC}/bacapp.c
-    ${BACNET_SRC}/bacdcode.c
-    ${BACNET_SRC}/bacdest.c
-    ${BACNET_SRC}/bacint.c
-    ${BACNET_SRC}/baclog.c
-    ${BACNET_SRC}/bacreal.c
-    ${BACNET_SRC}/bacstr.c
-    ${BACNET_SRC}/channel_value.c
-    ${BACNET_SRC}/datetime.c
-    ${BACNET_SRC}/timestamp.c
-    ${BACNET_SRC}/basic/sys/days.c
-    ${BACNET_SRC}/bacdevobjpropref.c
-    ${BACNET_SRC}/bactext.c
-    ${BACNET_SRC}/indtext.c
-    ${BACNET_SRC}/lighting.c
-    ${BACNET_SRC}/proplist.c
-    ${BACNET_SRC}/shed_level.c
-    ${BACNET_SRC}/timer_value.c
-    ${BACNET_SRC}/hostnport.c
-    ${BACNET_SRC}/dailyschedule.c
-    ${BACNET_SRC}/weeklyschedule.c
-    ${BACNET_SRC}/calendar_entry.c
-    ${BACNET_SRC}/special_event.c
-    ${BACNET_SRC}/basic/sys/bigend.c
-    ${BACNET_SRC}/bactimevalue.c
-    ${BACNET_SRC}/secure_connect.c
+    ${BACNET_BASE}/src/bacnet/bacaction.c
+    ${BACNET_BASE}/src/bacnet/bacaddr.c
+    ${BACNET_BASE}/src/bacnet/bacapp.c
+    ${BACNET_BASE}/src/bacnet/bacdcode.c
+    ${BACNET_BASE}/src/bacnet/bacdest.c
+    ${BACNET_BASE}/src/bacnet/bacdevobjpropref.c
+    ${BACNET_BASE}/src/bacnet/bacint.c
+    ${BACNET_BASE}/src/bacnet/baclog.c
+    ${BACNET_BASE}/src/bacnet/bacreal.c
+    ${BACNET_BASE}/src/bacnet/bacstr.c
+    ${BACNET_BASE}/src/bacnet/bactext.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/bigend.c
+    ${BACNET_BASE}/src/bacnet/datetime.c
+    ${BACNET_BASE}/src/bacnet/basic/sys/days.c
+    ${BACNET_BASE}/src/bacnet/hostnport.c
+    ${BACNET_BASE}/src/bacnet/lighting.c
+    ${BACNET_BASE}/src/bacnet/proplist.c
+    ${BACNET_BASE}/src/bacnet/shed_level.c
+    ${BACNET_BASE}/src/bacnet/timer_value.c
+    ${BACNET_BASE}/src/bacnet/timestamp.c
+    ${BACNET_BASE}/src/bacnet/indtext.c
+    ${BACNET_BASE}/src/bacnet/weeklyschedule.c
+    ${BACNET_BASE}/src/bacnet/bactimevalue.c
+    ${BACNET_BASE}/src/bacnet/dailyschedule.c
+    ${BACNET_BASE}/src/bacnet/calendar_entry.c
+    ${BACNET_BASE}/src/bacnet/special_event.c
+    ${BACNET_BASE}/src/bacnet/channel_value.c
+    ${BACNET_BASE}/src/bacnet/secure_connect.c
+    ${BACNET_TEST_PATH}/src/main.c
     )
 
   set(CONF_FILE "${CONF_FILE};prj.unit_testing.conf")


### PR DESCRIPTION
- Updated multiple CMakeLists.txt files in the BACnet test directories to replace relative source paths with absolute paths from the BACNET_BASE directory.
- Removed unnecessary commented-out code and consolidated source file lists for clarity and maintainability.
- Ensured that all relevant BACnet source files are included for unit testing across various test cases, including IAM, IHAVE, INDText, Lighting, LSO, Memcopy, NPDU, Property, PTransfer, RD, Reject, RP, RPM, Timestamp, TimeSync, WhoHas, and WhoIs.
- Added main.c file references for unit testing in each test directory.